### PR TITLE
fix: use InjectionToken, OpaqueToken is deprecated

### DIFF
--- a/src/app/app.tokens.ts
+++ b/src/app/app.tokens.ts
@@ -1,3 +1,4 @@
-import { OpaqueToken } from '@angular/core';
+import * as firebase from 'firebase';
+import { InjectionToken } from '@angular/core';
 
-export const DATABASE = new OpaqueToken('Database');
+export const DATABASE = new InjectionToken<firebase.database.Database>('Database');


### PR DESCRIPTION
This also comes with the benefit that we can declare the return type
of what the injector returns when asking for `DATABASE`.