### PR TITLE
feat(LabStorageService): add createLabFromTemplate() method

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { RouterModule } from '@angular/router';
 import { RemoteLabExecService } from './remote-lab-exec.service';
 import { LabStorageService } from './lab-storage.service';
 import { AuthService, FirebaseAuthService, OfflineAuthService } from './auth';
+import { LabTemplateService, InMemoryLabTemplateService } from './lab-template.service';
 
 import { AppComponent } from './app.component';
 import { AceEditorComponent } from './ace-editor/ace-editor.component';
@@ -53,7 +54,8 @@ export function databaseFactory() {
     LabStorageService,
     LabResolver,
     { provide: DATABASE, useFactory: databaseFactory },
-    { provide: AuthService, useClass: environment.offline ? OfflineAuthService : FirebaseAuthService }
+    { provide: AuthService, useClass: environment.offline ? OfflineAuthService : FirebaseAuthService },
+    { provide: LabTemplateService, useClass: InMemoryLabTemplateService }
   ],
   entryComponents: [AddFileDialogComponent],
   bootstrap: [AppComponent]

--- a/src/app/data/lab-templates.ts
+++ b/src/app/data/lab-templates.ts
@@ -1,0 +1,13 @@
+import { SIMPLE_XOR_LAB_CODE } from './xor-lab-code';
+
+export const LAB_TEMPLATES = {
+  'XOR': {
+    name: 'XOR Template',
+    description: '',
+    tags: [],
+    files: [{
+      name: 'main.py',
+      content: SIMPLE_XOR_LAB_CODE
+    }]
+  }
+};

--- a/src/app/data/xor-lab-code.ts
+++ b/src/app/data/xor-lab-code.ts
@@ -1,5 +1,4 @@
-export const DEFAULT_LAB_CODE = `
-import numpy as np
+export const SIMPLE_XOR_LAB_CODE = `import numpy as np
 from keras.models import Sequential
 from keras.layers.core import Dense
 
@@ -20,3 +19,4 @@ model.compile(loss='mean_squared_error',
 model.fit(training_data, target_data, nb_epoch=500, verbose=2)
 
 print model.predict(training_data).round()`;
+

--- a/src/app/lab-storage.service.spec.ts
+++ b/src/app/lab-storage.service.spec.ts
@@ -3,9 +3,10 @@ import { Inject } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { LabStorageService } from './lab-storage.service';
+import { LabTemplateService, InMemoryLabTemplateService } from './lab-template.service';
 import { AuthService } from './auth';
 import { DATABASE } from './app.tokens';
-import { DEFAULT_LAB_CODE } from './default-lab';
+import { LAB_TEMPLATES } from './data/lab-templates';
 
 let testLab = {
   id: 'some-id',
@@ -32,6 +33,7 @@ let databaseStub = {
 describe('LabStorageService', () => {
 
   let labStorageService: LabStorageService;
+  let labTemplateService: LabTemplateService;
   let authService: AuthService;
   let db;
 
@@ -39,12 +41,14 @@ describe('LabStorageService', () => {
     TestBed.configureTestingModule({
       providers: [
         LabStorageService,
+        { provide: LabTemplateService, useClass: InMemoryLabTemplateService },
         { provide: AuthService, useValue: authServiceStub },
         { provide: DATABASE, useValue: databaseStub }
       ]
     });
 
     labStorageService = TestBed.get(LabStorageService);
+    labTemplateService = TestBed.get(LabTemplateService);
     authService = TestBed.get(AuthService);
     db = TestBed.get(DATABASE);
 
@@ -60,7 +64,7 @@ describe('LabStorageService', () => {
         expect(lab).toBeDefined();
         expect(lab.files.length).toBe(1);
         expect(lab.files[0].name).toEqual('main.py');
-        expect(lab.files[0].content).toEqual(DEFAULT_LAB_CODE);
+        expect(lab.files[0].content).toEqual('');
       });
     });
 
@@ -75,6 +79,25 @@ describe('LabStorageService', () => {
         expect(lab.description).toEqual(existingLab.description);
         expect(lab.tags).toEqual(existingLab.tags);
         expect(lab.files.length).toBe(0);
+      });
+    });
+  });
+
+  describe('.createLabFromTemplate()', () => {
+
+    it('should create lab from given template', () => {
+
+      const TEMPLATE = 'XOR';
+
+      spyOn(labTemplateService, 'getTemplate').and.returnValue(Observable.of(LAB_TEMPLATES[TEMPLATE]));
+      spyOn(labStorageService, 'createLab').and.callThrough();
+
+      labStorageService.createLabFromTemplate(TEMPLATE).subscribe(lab => {
+        expect(labTemplateService.getTemplate).toHaveBeenCalledWith(TEMPLATE);
+        expect(labStorageService.createLab).toHaveBeenCalledWith(LAB_TEMPLATES[TEMPLATE]);
+        expect(lab.files.length).toBe(1);
+        expect(lab.name).toEqual(`Fork of ${LAB_TEMPLATES[TEMPLATE].name}`);
+        expect(lab.files[0].content).toEqual(LAB_TEMPLATES[TEMPLATE].files[0].content);
       });
     });
   });

--- a/src/app/lab-template.service.spec.ts
+++ b/src/app/lab-template.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { LabTemplateService, InMemoryLabTemplateService } from './lab-template.service';
+import { LAB_TEMPLATES } from './data/lab-templates';
+
+describe('LabTemplateService', () => {
+
+  let labTemplateService: LabTemplateService;
+
+  describe('InMemoryLabTemplateService', () => {
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LabTemplateService, useClass: InMemoryLabTemplateService }
+        ]
+      });
+
+      labTemplateService = TestBed.get(LabTemplateService);
+    });
+
+    describe('getTemplate()', () => {
+
+      it('should emit a lab template by a given template name', () => {
+        labTemplateService.getTemplate('XOR').subscribe(tpl => {
+          expect(tpl).toEqual(LAB_TEMPLATES['XOR']);
+        });
+      });
+    });
+  });
+});

--- a/src/app/lab-template.service.ts
+++ b/src/app/lab-template.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { LabTemplate } from './models/lab';
+import { LAB_TEMPLATES } from './data/lab-templates';
+
+
+export abstract class LabTemplateService {
+  abstract getTemplate(name: string): Observable<LabTemplate>;
+}
+
+export class InMemoryLabTemplateService extends LabTemplateService {
+
+  getTemplate(name: string): Observable<LabTemplate> {
+    return Observable.of(LAB_TEMPLATES[name]);
+  }
+}

--- a/src/app/lab.resolver.spec.ts
+++ b/src/app/lab.resolver.spec.ts
@@ -13,6 +13,7 @@ describe('LabResolver', () => {
 
   let labStorageServiceStub = {
     createLab: () => {},
+    createLabFromTemplate: (arg) => {},
     getLab: (id) => {}
   };
 
@@ -30,7 +31,7 @@ describe('LabResolver', () => {
 
   describe('.resolve()', () => {
 
-    it('should resolve with new lab if no route param labid is given', () => {
+    it('should resolve with new lab from template if no route param labid is given', () => {
 
       let newLab: Lab = {
         id: 'new-lab',
@@ -43,10 +44,10 @@ describe('LabResolver', () => {
 
       let activatedRouteSnapshotStub = { params: {}, data: {} };
 
-      spyOn(labStorageService, 'createLab').and.returnValue(Observable.of(newLab));
+      spyOn(labStorageService, 'createLabFromTemplate').and.returnValue(Observable.of(newLab));
 
       labResolver.resolve(activatedRouteSnapshotStub).subscribe(lab => {
-        expect(labStorageService.createLab).toHaveBeenCalled();
+        expect(labStorageService.createLabFromTemplate).toHaveBeenCalled();
         expect(lab).toEqual(newLab);
       });
     });

--- a/src/app/lab.resolver.ts
+++ b/src/app/lab.resolver.ts
@@ -16,7 +16,7 @@ export class LabResolver implements Resolve<Lab> {
     // if we don't have any param, create a default lab
     // if we have an id, fetch the lab. If it fails, go for the default lab
     return !route.params['labid']
-            ? this.labStorageService.createLab()
+            ? this.labStorageService.createLabFromTemplate('XOR')
             : this.labStorageService.getLab(route.params['labid'])
                                     .map(lab => lab ? lab : this.labStorageService.createLab());
 

--- a/src/app/models/lab.ts
+++ b/src/app/models/lab.ts
@@ -11,13 +11,16 @@ export interface File {
   content: string;
 }
 
-export interface Lab {
-  id: string;
-  user_id: string;
+export interface LabTemplate {
   name: string;
   description: string;
   tags: string[];
   files: File[];
+}
+
+export interface Lab extends LabTemplate {
+  id: string;
+  user_id: string;
 }
 
 export class LabExecutionContext {


### PR DESCRIPTION
As discussed in #34, this introduces a new API to create labs from existing
templates such as the simple XOR lab we're creating every time a new user
visits the app.

Main changes:

- Introduces `LabTemplateService` which exposes APIs to work with lab templates

- `LabResolver.resolve()` now uses `createLabFromTemplate()` instead of `createLab()`

- `createLab()` now creates a lab with an empty file set, making it more suitable for #33

- `DEFAULT_LAB_CODE` is now `SIMPLE_XOR_CODE` and is consumed by `LabTemplateService`

Implements #34