### PR TITLE
feat(EditorView): add button for creating new labs

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { AceEditorComponent } from './ace-editor/ace-editor.component';
 import { PanelComponent } from './panel/panel.component';
 import { EditorViewComponent } from './editor-view/editor-view.component';
 import { AddFileDialogComponent } from './add-file-dialog/add-file-dialog.component';
+import { NavigationConfirmDialogComponent } from './navigation-confirm-dialog/navigation-confirm-dialog.component';
 import { FileTreeComponent } from './file-tree/file-tree.component';
 
 import { APP_ROUTES } from './app.routes';
@@ -38,7 +39,8 @@ export function databaseFactory() {
     PanelComponent,
     EditorViewComponent,
     AddFileDialogComponent,
-    FileTreeComponent
+    FileTreeComponent,
+    NavigationConfirmDialogComponent
   ],
   imports: [
     BrowserModule,
@@ -57,7 +59,10 @@ export function databaseFactory() {
     { provide: AuthService, useClass: environment.offline ? OfflineAuthService : FirebaseAuthService },
     { provide: LabTemplateService, useClass: InMemoryLabTemplateService }
   ],
-  entryComponents: [AddFileDialogComponent],
+  entryComponents: [
+    AddFileDialogComponent,
+    NavigationConfirmDialogComponent
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/data/lab-templates.ts
+++ b/src/app/data/lab-templates.ts
@@ -1,7 +1,7 @@
 import { SIMPLE_XOR_LAB_CODE } from './xor-lab-code';
 
 export const LAB_TEMPLATES = {
-  'XOR': {
+  'xor': {
     name: 'XOR Template',
     description: '',
     tags: [],

--- a/src/app/editor-view/editor-view.component.html
+++ b/src/app/editor-view/editor-view.component.html
@@ -6,6 +6,7 @@
     <button md-button (click)="stop(context)" *ngIf="context.isRunning()"><md-icon>stop</md-icon> Stop</button>
     <button *ngIf="lab.user_id == user?.uid" md-button (click)="save(lab)"><md-icon>save</md-icon> Save</button>
     <button *ngIf="lab.user_id != user?.uid" md-button (click)="fork(lab)"><md-icon>share</md-icon> Fork</button>
+    <button md-button (click)="create()"><md-icon>add</md-icon> New</button>
 
     <!-- menu opens when trigger button is clicked -->
     <button md-icon-button [md-menu-trigger-for]="menu">

--- a/src/app/lab-storage.service.spec.ts
+++ b/src/app/lab-storage.service.spec.ts
@@ -3,7 +3,7 @@ import { Inject } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 
 import { LabStorageService } from './lab-storage.service';
-import { LabTemplateService, InMemoryLabTemplateService } from './lab-template.service';
+import { LabTemplateService, InMemoryLabTemplateService, DEFAULT_LAB_TPL_ID } from './lab-template.service';
 import { AuthService } from './auth';
 import { DATABASE } from './app.tokens';
 import { LAB_TEMPLATES } from './data/lab-templates';
@@ -87,7 +87,7 @@ describe('LabStorageService', () => {
 
     it('should create lab from given template', () => {
 
-      const TEMPLATE = 'XOR';
+      const TEMPLATE = DEFAULT_LAB_TPL_ID;
 
       spyOn(labTemplateService, 'getTemplate').and.returnValue(Observable.of(LAB_TEMPLATES[TEMPLATE]));
       spyOn(labStorageService, 'createLab').and.callThrough();

--- a/src/app/lab-template.service.spec.ts
+++ b/src/app/lab-template.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { LabTemplateService, InMemoryLabTemplateService } from './lab-template.service';
+import { LabTemplateService, InMemoryLabTemplateService, DEFAULT_LAB_TPL_ID } from './lab-template.service';
 import { LAB_TEMPLATES } from './data/lab-templates';
 
 describe('LabTemplateService', () => {
@@ -21,8 +21,8 @@ describe('LabTemplateService', () => {
     describe('getTemplate()', () => {
 
       it('should emit a lab template by a given template name', () => {
-        labTemplateService.getTemplate('XOR').subscribe(tpl => {
-          expect(tpl).toEqual(LAB_TEMPLATES['XOR']);
+        labTemplateService.getTemplate(DEFAULT_LAB_TPL_ID).subscribe(tpl => {
+          expect(tpl).toEqual(LAB_TEMPLATES[DEFAULT_LAB_TPL_ID]);
         });
       });
     });

--- a/src/app/lab-template.service.ts
+++ b/src/app/lab-template.service.ts
@@ -3,6 +3,8 @@ import { Observable } from 'rxjs/Observable';
 import { LabTemplate } from './models/lab';
 import { LAB_TEMPLATES } from './data/lab-templates';
 
+export const BLANK_LAB_TPL_ID = 'blank';
+export const DEFAULT_LAB_TPL_ID = 'xor';
 
 export abstract class LabTemplateService {
   abstract getTemplate(name: string): Observable<LabTemplate>;

--- a/src/app/lab.resolver.spec.ts
+++ b/src/app/lab.resolver.spec.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { LabResolver } from './lab.resolver';
 import { LabStorageService } from './lab-storage.service';
+import { BLANK_LAB_TPL_ID, DEFAULT_LAB_TPL_ID } from './lab-template.service';
 
 import { Lab } from './models/lab';
 
@@ -31,7 +32,7 @@ describe('LabResolver', () => {
 
   describe('.resolve()', () => {
 
-    it('should resolve with new lab from template if no route param labid is given', () => {
+    it('should resolve with new lab from default template if no route param labid is given', () => {
 
       let newLab: Lab = {
         id: 'new-lab',
@@ -42,12 +43,62 @@ describe('LabResolver', () => {
         files: []
       };
 
-      let activatedRouteSnapshotStub = { params: {}, data: {} };
+      let activatedRouteSnapshotStub = { params: {}, data: {}, queryParams: {} };
 
       spyOn(labStorageService, 'createLabFromTemplate').and.returnValue(Observable.of(newLab));
 
       labResolver.resolve(activatedRouteSnapshotStub).subscribe(lab => {
-        expect(labStorageService.createLabFromTemplate).toHaveBeenCalled();
+        expect(labStorageService.createLabFromTemplate).toHaveBeenCalledWith(DEFAULT_LAB_TPL_ID);
+        expect(lab).toEqual(newLab);
+      });
+    });
+
+    it('should resolve with blank lab, if template param for blank is given', () => {
+
+      let newLab: Lab = {
+        id: 'new-lab',
+        user_id: 'user-id',
+        name: 'New Lab',
+        description: 'this is a new lab',
+        tags: [],
+        files: []
+      };
+
+      let activatedRouteSnapshotStub = {
+        params: {},
+        data: {},
+        queryParams: { tpl: BLANK_LAB_TPL_ID }
+      };
+
+      spyOn(labStorageService, 'createLab').and.returnValue(Observable.of(newLab));
+
+      labResolver.resolve(activatedRouteSnapshotStub).subscribe(lab => {
+        expect(labStorageService.createLab).toHaveBeenCalled();
+        expect(lab).toEqual(newLab);
+      });
+    });
+
+    it('should resolve with lab from template, if template param is given', () => {
+
+      let newLab: Lab = {
+        id: 'new-lab',
+        user_id: 'user-id',
+        name: 'New Lab',
+        description: 'this is a new lab',
+        tags: [],
+        files: []
+      };
+
+      let activatedRouteSnapshotStub = {
+        params: {},
+        data: {},
+        queryParams: { tpl: 'any'}
+      };
+
+      spyOn(labStorageService, 'createLabFromTemplate').and.returnValue(Observable.of(newLab));
+
+      labResolver.resolve(activatedRouteSnapshotStub).subscribe(lab => {
+        expect(labStorageService.createLabFromTemplate).toHaveBeenCalledWith('any');
         expect(lab).toEqual(newLab);
       });
     });

--- a/src/app/navigation-confirm-dialog/navigation-confirm-dialog.component.spec.ts
+++ b/src/app/navigation-confirm-dialog/navigation-confirm-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NavigationConfirmDialogComponent } from './navigation-confirm-dialog.component';
+
+describe('NavigationConfirmDialogComponent', () => {
+  let component: NavigationConfirmDialogComponent;
+  let fixture: ComponentFixture<NavigationConfirmDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NavigationConfirmDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NavigationConfirmDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/navigation-confirm-dialog/navigation-confirm-dialog.component.ts
+++ b/src/app/navigation-confirm-dialog/navigation-confirm-dialog.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { MdDialogRef } from '@angular/material';
+
+@Component({
+  selector: 'ml-navigation-confirm-dialog',
+  template: `
+    <p>Are you sure? Unsaved changes will be gone.</p>
+    <div style="margin-top: 1em; text-align: center;">
+      <button md-raised-button (click)="dialogRef.close(true)">Yes</button>
+      <button md-raised-button type="button" (click)="dialogRef.close()">Close</button>
+    </div>
+  `
+})
+export class NavigationConfirmDialogComponent {
+
+  constructor(private dialogRef: MdDialogRef<NavigationConfirmDialogComponent>) { }
+}


### PR DESCRIPTION
This commit adds a button to EditorViewComponent's UI which lets the user
create a new lab by navigating to '/?tpl=blank'.

To make this work, LabResolver had to be made a bit smart to figure out
how a lab needs to be created. With this commit the followng rules apply:

- if a lab id is given, fetch it, if it fails, create a new one
- if no lab id is given, check if a template id is given. If given, create
  lab from template, unless template id is specified as 'blank'. Then create
  new blank one
- if no lab id and no template id is given, create lab from default template
  (which is currently the XOR sample)

Closes #33