### PR TITLE
feat(EditorView): add support for linking anonymous users with perman…

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -7,5 +7,6 @@ export abstract class AuthService {
   abstract requireAuthOnce(): Observable<User>;
   abstract signOut(): Observable<any>;
   abstract signInWithGitHub(): Observable<User>;
+  abstract linkOrSignInWithGitHub(): Observable<User>;
 }
 

--- a/src/app/auth/firebase-auth.service.ts
+++ b/src/app/auth/firebase-auth.service.ts
@@ -39,8 +39,34 @@ export class FirebaseAuthService extends AuthService {
     let loginPromise = firebase.auth()
                                .signInWithPopup(new firebase.auth.GithubAuthProvider())
                                .then(result => result.user);
-
     return Observable.fromPromise(<Promise<any>>loginPromise);
+  }
+
+  linkOrSignInWithGitHub(): Observable<User> {
+    let linkPromise = firebase.auth()
+                              .currentUser
+                              .linkWithPopup(new firebase.auth.GithubAuthProvider())
+                              .then(result => {
+                                // `linkWithPopup()` doesn't actually update the top-level properties
+                                // of the authenticated user object. It only adds `providerData` for the
+                                // dedicated provider (GitHub) to that object. This is because it's possible
+                                // to link an account with multiple providers. If we want `user.photoURL`
+                                // to be defined, we have to assign that value explicitely from the retreived
+                                // `providerData`.
+                                //
+                                // More info: http://stackoverflow.com/questions/42766440/why-does-firebase-linkwithpopup-not-set-the-user-photourl-in-firebase
+                                let currentUser = firebase.auth().currentUser;
+                                currentUser.updateProfile({
+                                  displayName: currentUser.providerData[0].displayName,
+                                  photoURL: currentUser.providerData[0].photoURL
+                                });
+                                return currentUser;
+                              });
+
+    // If a user has been permanentely linked/authenticated already and tries
+    // to link again, firebase will throw an error. That's when we know that
+    // user credentials do already exist and we can simply sign in using GitHub.
+    return Observable.fromPromise(<Promise<any>>linkPromise).catch(error => this.signInWithGitHub());
   }
 }
 

--- a/src/app/auth/offline-auth.service.ts
+++ b/src/app/auth/offline-auth.service.ts
@@ -37,6 +37,10 @@ export class OfflineAuthService implements OfflineAuth {
     return Observable.of(this.user);
   }
 
+  linkOrSignInWithGitHub(): Observable<User> {
+    return this.signInWithGitHub();
+  }
+
   signOut(): Observable<any> {
     this.user.isAnonymous = true;
     return Observable.of();

--- a/src/app/editor-view/editor-view.component.html
+++ b/src/app/editor-view/editor-view.component.html
@@ -10,7 +10,7 @@
     <!-- menu opens when trigger button is clicked -->
     <button md-icon-button [md-menu-trigger-for]="menu">
       <md-icon *ngIf="user?.isAnonymous">more_vert</md-icon>
-      <img *ngIf="user && !user.isAnonymous" src="{{user.photoURL}}" alt="{{user.displayName}} profile picture" class="ml-login-avatar">
+      <img *ngIf="user && user.photoURL" [src]="user.photoURL" alt="{{user.displayName}} profile picture" class="ml-login-avatar">
     </button>
 
     <md-menu #menu="mdMenu">

--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -110,7 +110,7 @@ export class EditorViewComponent implements OnInit {
   }
 
   loginWithGitHub() {
-    this.authService.signInWithGitHub().subscribe();
+    this.authService.linkOrSignInWithGitHub().subscribe();
   }
 
   logout() {

--- a/src/app/rx.operators.ts
+++ b/src/app/rx.operators.ts
@@ -7,3 +7,4 @@ import 'rxjs/add/operator/takeWhile';
 import 'rxjs/add/operator/publishLast';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/catch';


### PR DESCRIPTION
…ent users

As discussed in #38, anonymous users should be able to preserve their created labs
when they authenticate via GitHub. This commit introduces a new API
`AuthService.linkOrSignInWithGitHub(): Observable<User>`, which always tries
to link the anonymous user on sign in first and falls back to normal sign in if
it throws (e.g. when credentials have been linked already).

Closes #38