### PR TITLE
refactor(Toolbar): move toolbar logic into its own component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AuthService, FirebaseAuthService, OfflineAuthService } from './auth';
 import { LabTemplateService, InMemoryLabTemplateService } from './lab-template.service';
 
 import { AppComponent } from './app.component';
+import { ToolbarComponent } from './toolbar/toolbar.component';
 import { AceEditorComponent } from './ace-editor/ace-editor.component';
 import { PanelComponent } from './panel/panel.component';
 import { EditorViewComponent } from './editor-view/editor-view.component';
@@ -35,6 +36,7 @@ export function databaseFactory() {
 @NgModule({
   declarations: [
     AppComponent,
+    ToolbarComponent,
     AceEditorComponent,
     PanelComponent,
     EditorViewComponent,

--- a/src/app/editor-view/editor-view.component.html
+++ b/src/app/editor-view/editor-view.component.html
@@ -1,36 +1,9 @@
 <div fxLayout="column" style="height: 100%;">
-  <md-toolbar color="primary" class="ml-toolbar">
-    <div fxLayout fxLayoutAlign="space-between center" fxFlex class="padded">
-      <span class="ml-logo">Machine<span>Labs</span></span>
-
-      <div fxFlex class="ml-toolbar__lab-name">
-        <md-input-container>
-          <input mdInput [readOnly]="true" [(ngModel)]="lab.name">
-        </md-input-container>
-        <button md-icon-button><md-icon>edit</md-icon></button>
-      </div>
-
-      <div fxLayout fxLayoutAlign="end">
-        <div fxLayout class="ml-toolbar__cta-bar">
-          <button md-button (click)="run(lab)" *ngIf="!context.isRunning()"><md-icon>cached</md-icon> Run</button>
-          <button md-button (click)="stop(context)" *ngIf="context.isRunning()"><md-icon>stop</md-icon> Stop</button>
-          <button *ngIf="lab.user_id == user?.uid" md-button (click)="save(lab)"><md-icon>save</md-icon> Save</button>
-          <button md-button (click)="fork(lab)"><md-icon>share</md-icon> Fork</button>
-          <button md-button (click)="create()"><md-icon>add</md-icon> New</button>
-        </div>
-
-        <button md-icon-button [md-menu-trigger-for]="menu">
-          <md-icon *ngIf="user?.isAnonymous">more_vert</md-icon>
-          <img *ngIf="user && user.photoURL" [src]="user.photoURL" alt="{{user.displayName}} profile picture" class="ml-login-avatar">
-        </button>
-
-        <md-menu #menu="mdMenu">
-          <button md-menu-item *ngIf="user?.isAnonymous" (click)="loginWithGitHub()"><md-icon>perm_identity</md-icon>Login with GitHub</button>
-          <button *ngIf="!user?.isAnonymous" (click)="logout()" md-menu-item><md-icon>exit_to_app</md-icon>Sign Out</button>
-        </md-menu>
-      </div>
-    </div>
-  </md-toolbar>
+<ml-toolbar
+  [lab]="lab"
+  [context]="context"
+  (action)="toolbarAction($event)"
+  ></ml-toolbar>
   <md-sidenav-container>
     <md-sidenav opened="true" mode="side" #sidenav class="ml-sidebar">
       <ml-panel panelTitle="Files">

--- a/src/app/editor-view/editor-view.component.scss
+++ b/src/app/editor-view/editor-view.component.scss
@@ -3,59 +3,6 @@
   height: 100%;
 }
 
-.ml-toolbar {
-  background: #2196f3;
-  color: #fff;
-}
-
-.padded {
-  padding-right: 20px;
-}
-
-.ml-logo {
-  font-size: 1.2em;
-  font-weight: 400;
-  margin: 0;
-  padding: 0.8em;
-  text-align: center;
-  margin-right: 3.8em;
-
-  span {
-    font-weight: 600;
-  }
-}
-
-.ml-toolbar__lab-name {
-  margin-left: 4.5em;
-  input {
-    font-size: 0.75em;
-  }
-
-  [md-icon-button] {
-    margin-top: 14px;
-  }
-
-  md-icon {
-    font-size: 1.4em;
-  }
-}
-
-.ml-toolbar__cta-bar {
-  margin-right: 0.4em;
-  [md-button] {
-    margin-left: 0.2em;
-
-    &:first-child {
-      margin-left: 0;
-    }
-  }
-}
-
-.ml-login-avatar {
-  border-radius: 50%;
-  width: 2.5em;
-}
-
 md-sidenav { width: 350px; }
 
 .ml-footer {

--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -9,8 +9,7 @@ import { LabStorageService } from '../lab-storage.service';
 import { BLANK_LAB_TPL_ID } from '../lab-template.service';
 import { Observable } from 'rxjs/Observable';
 import { Lab, LabExecutionContext, File } from '../models/lab';
-import { User } from '../models/user';
-import { AuthService } from '../auth/auth.service';
+import { ToolbarAction, ToolbarActionTypes } from '../toolbar/toolbar.component';
 
 @Component({
   selector: 'ml-editor-view',
@@ -33,13 +32,10 @@ export class EditorViewComponent implements OnInit {
 
   navigationConfirmDialogRef: MdDialogRef<NavigationConfirmDialogComponent>;
 
-  user: User;
-
   constructor (private rleService: RemoteLabExecService,
                private labStorageService: LabStorageService,
                private route: ActivatedRoute,
                private dialog: MdDialog,
-               private authService: AuthService,
                private location: Location,
                private router: Router) {
   }
@@ -47,12 +43,17 @@ export class EditorViewComponent implements OnInit {
   ngOnInit () {
     this.context = new LabExecutionContext();
     this.route.data.map(data => data['lab'])
-              .subscribe(lab =>  {
-                this.lab = lab;
-                this.activeFile = this.lab.files[0];
-              });
+              .subscribe(lab =>  this.initLab(lab));
+  }
 
-    this.authService.requireAuth().subscribe(user => this.user = user);
+  toolbarAction(action: ToolbarAction) {
+    switch (action.type) {
+      case ToolbarActionTypes.Run: this.run(action.data); break;
+      case ToolbarActionTypes.Stop: this.stop(action.data); break;
+      case ToolbarActionTypes.Save: this.save(action.data); break;
+      case ToolbarActionTypes.Fork: this.fork(action.data); break;
+      case ToolbarActionTypes.Create: this.create(); break;
+    }
   }
 
   run(lab: Lab) {
@@ -133,14 +134,6 @@ export class EditorViewComponent implements OnInit {
         this.lab.files.push(file);
         this.openFile(file);
       });
-  }
-
-  loginWithGitHub() {
-    this.authService.linkOrSignInWithGitHub().subscribe();
-  }
-
-  logout() {
-    this.authService.signOut().subscribe();
   }
 
   initLab(lab) {

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -1,0 +1,32 @@
+<md-toolbar color="primary" class="ml-toolbar">
+  <div fxLayout fxLayoutAlign="space-between center" fxFlex class="padded">
+    <span class="ml-logo">Machine<span>Labs</span></span>
+
+    <div fxFlex class="ml-toolbar__lab-name">
+      <md-input-container>
+        <input mdInput [readOnly]="true" [(ngModel)]="lab.name">
+      </md-input-container>
+      <button md-icon-button><md-icon>edit</md-icon></button>
+    </div>
+
+    <div fxLayout fxLayoutAlign="end">
+      <div fxLayout class="ml-toolbar__cta-bar">
+        <button md-button (click)="emitAction(ToolbarActionTypes.Run, lab)" *ngIf="!context.isRunning()"><md-icon>cached</md-icon> Run</button>
+        <button md-button (click)="emitAction(ToolbarActionTypes.Stop, context)" *ngIf="context.isRunning()"><md-icon>stop</md-icon> Stop</button>
+        <button md-button (click)="emitAction(ToolbarActionTypes.Save, lab)" *ngIf="lab.user_id == user?.uid"><md-icon>save</md-icon> Save</button>
+        <button md-button (click)="emitAction(ToolbarActionTypes.Fork, lab)"><md-icon>share</md-icon> Fork</button>
+        <button md-button (click)="emitAction(ToolbarActionTypes.Create)"><md-icon>add</md-icon> New</button>
+      </div>
+
+      <button md-icon-button [md-menu-trigger-for]="menu">
+        <md-icon *ngIf="user?.isAnonymous">more_vert</md-icon>
+        <img *ngIf="user && user.photoURL" [src]="user.photoURL" alt="{{user.displayName}} profile picture" class="ml-login-avatar">
+      </button>
+
+      <md-menu #menu="mdMenu">
+        <button md-menu-item *ngIf="user?.isAnonymous" (click)="loginWithGitHub()"><md-icon>perm_identity</md-icon>Login with GitHub</button>
+        <button *ngIf="!user?.isAnonymous" (click)="logout()" md-menu-item><md-icon>exit_to_app</md-icon>Sign Out</button>
+      </md-menu>
+    </div>
+  </div>
+</md-toolbar>

--- a/src/app/toolbar/toolbar.component.scss
+++ b/src/app/toolbar/toolbar.component.scss
@@ -1,0 +1,53 @@
+.ml-toolbar {
+  background: #2196f3;
+  color: #fff;
+}
+
+.padded {
+  padding-right: 20px;
+}
+
+.ml-logo {
+  font-size: 1.2em;
+  font-weight: 400;
+  margin: 0;
+  padding: 0.8em;
+  text-align: center;
+  margin-right: 3.8em;
+
+  span {
+    font-weight: 600;
+  }
+}
+
+.ml-toolbar__lab-name {
+  margin-left: 4.5em;
+  input {
+    font-size: 0.75em;
+  }
+
+  [md-icon-button] {
+    margin-top: 14px;
+  }
+
+  md-icon {
+    font-size: 1.4em;
+  }
+}
+
+.ml-toolbar__cta-bar {
+  margin-right: 0.4em;
+  [md-button] {
+    margin-left: 0.2em;
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+}
+
+.ml-login-avatar {
+  border-radius: 50%;
+  width: 2.5em;
+}
+

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -1,0 +1,123 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MaterialModule } from '@angular/material';
+import { Observable } from 'rxjs/Observable';
+import { AuthService, dummyUser } from '../auth/';
+import { ToolbarComponent, ToolbarActionTypes } from './toolbar.component';
+import { LabExecutionContext, ExecutionStatus } from '../models/lab';
+
+let authServiceStub = {
+  requireAuth: () => {},
+  linkOrSignInWithGitHub: () => {}
+};
+
+let testLab = {
+  id: 'some-id',
+  user_id: 'user id',
+  name: 'Existing lab',
+  description: '',
+  tags: ['existing'],
+  files: []
+};
+
+describe('ToolbarComponent', () => {
+  let component: ToolbarComponent;
+  let fixture: ComponentFixture<ToolbarComponent>;
+  let authService: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ToolbarComponent],
+      imports: [MaterialModule, CommonModule, FormsModule],
+      providers: [{ provide: AuthService, useValue: authServiceStub }]
+    })
+
+    fixture = TestBed.createComponent(ToolbarComponent);
+    component = fixture.componentInstance;
+    authService = TestBed.get(AuthService);
+
+    let lab = Object.assign({}, testLab);
+    component.context = new LabExecutionContext(lab);
+    component.lab = lab;
+    spyOn(authService, 'requireAuth').and.returnValue(Observable.of(dummyUser));
+    fixture.detectChanges();
+  });
+
+  it('should authenticate user on initialization', () => {
+    expect(authService.requireAuth).toHaveBeenCalled();
+  });
+
+  describe('Toolbar Actions', () => {
+
+    it('should emit run action', () => {
+      let runButton = fixture.debugElement.queryAll(By.css('.ml-toolbar__cta-bar button'))[0];
+
+      component.action.subscribe(action => {
+        expect(action.type).toBe(ToolbarActionTypes.Run);
+      });
+
+      runButton.triggerEventHandler('click', null);
+    });
+
+    it('should emit stop action', () => {
+      let lab = Object.assign({}, testLab);
+
+      component.context = new LabExecutionContext(lab);
+      component.context.status = ExecutionStatus.Running;
+      component.lab = lab;
+      fixture.detectChanges();
+
+      // When lab is running, stop button is the first
+      let stopButton = fixture.debugElement.queryAll(By.css('.ml-toolbar__cta-bar button'))[0];
+
+      component.action.subscribe(action => {
+        expect(action.type).toBe(ToolbarActionTypes.Stop);
+      });
+
+      stopButton.triggerEventHandler('click', null);
+    });
+
+    it('should emit save action', () => {
+      let lab = Object.assign({}, testLab);
+      lab.user_id = 'some unique id';
+
+      component.context = new LabExecutionContext(lab);
+      component.lab = lab;
+      fixture.detectChanges();
+
+      // When lab isn't running, save button is the second
+      let saveButton = fixture.debugElement.queryAll(By.css('.ml-toolbar__cta-bar button'))[1];
+
+      component.action.subscribe(action => {
+        expect(action.type).toBe(ToolbarActionTypes.Save);
+      });
+
+      saveButton.triggerEventHandler('click', null);
+    });
+
+    it('should emit fork action', () => {
+      // When user doesn't own lab and lab isn't running, fork button is second
+      let forkButton = fixture.debugElement.queryAll(By.css('.ml-toolbar__cta-bar button'))[1];
+
+      component.action.subscribe(action => {
+        expect(action.type).toBe(ToolbarActionTypes.Fork);
+      });
+
+      forkButton.triggerEventHandler('click', null);
+    });
+
+    it('should emit create action', () => {
+      // When user doesn't own lab and lab isn't running, add button is third
+      let createButton = fixture.debugElement.queryAll(By.css('.ml-toolbar__cta-bar button'))[2];
+
+      component.action.subscribe(action => {
+        expect(action.type).toBe(ToolbarActionTypes.Create);
+      });
+
+      createButton.triggerEventHandler('click', null);
+    });
+  });
+});

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,0 +1,49 @@
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { Lab, LabExecutionContext } from '../models/lab';
+import { User } from '../models/user';
+import { AuthService } from '../auth/auth.service';
+
+export enum ToolbarActionTypes {
+  Run, Stop, Save, Fork, Create
+}
+
+export interface ToolbarAction {
+  type: ToolbarActionTypes;
+  data?: any;
+}
+
+@Component({
+  selector: 'ml-toolbar',
+  templateUrl: './toolbar.component.html',
+  styleUrls: ['./toolbar.component.scss']
+})
+export class ToolbarComponent implements OnInit {
+
+  @Input() lab: Lab;
+
+  @Input() context: LabExecutionContext;
+
+  @Output() action = new EventEmitter<ToolbarAction>();
+
+  private user: User;
+
+  ToolbarActionTypes = ToolbarActionTypes;
+
+  constructor(private authService: AuthService) {}
+
+  ngOnInit() {
+    this.authService.requireAuth().subscribe(user => this.user = user);
+  }
+
+  emitAction(action: ToolbarActionTypes, data?: any) {
+    this.action.emit({ type: action, data });
+  }
+
+  loginWithGitHub() {
+    this.authService.linkOrSignInWithGitHub().subscribe();
+  }
+
+  logout() {
+    this.authService.signOut().subscribe();
+  }
+}


### PR DESCRIPTION
As discussed in #45, this commit encapsulate ML's toolbar into its own `Toolbar`
component including its logic. This component is now consumed by `EditorViewComponent`
like this:

```
<ml-toolbar [lab]="lab" [context]="context" action="toolbarAction($event)">
</ml-toolbar>
```

While the following toolbar actions have been introduced:

```
enum ToolbarActionTypes {
  Run, Stop, Fork, Save, New
}
```

`ToolbarComponent` also handles authentication but doesn't expose output events as
those are considered private logic.

Closes #45