### PR TITLE
feat(Toolbar): allow user to change lab name

### DIFF
--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -3,10 +3,15 @@
     <span class="ml-logo">Machine<span>Labs</span></span>
 
     <div fxFlex class="ml-toolbar__lab-name">
-      <md-input-container>
-        <input mdInput [readOnly]="true" [(ngModel)]="lab.name">
+      <span *ngIf="!editing">{{lab.name}}</span>
+      <md-input-container *ngIf="editing">
+        <input
+          mdInput
+          (blur)="editing = false"
+          (keydown.enter)="editing = false"
+          [(ngModel)]="lab.name">
       </md-input-container>
-      <button md-icon-button><md-icon>edit</md-icon></button>
+      <button *ngIf="lab.user_id == user?.uid" md-icon-button type="button" (click)="editing = !editing"><md-icon>edit</md-icon></button>
     </div>
 
     <div fxLayout fxLayoutAlign="end">

--- a/src/app/toolbar/toolbar.component.scss
+++ b/src/app/toolbar/toolbar.component.scss
@@ -21,13 +21,16 @@
 }
 
 .ml-toolbar__lab-name {
+
+  > span {
+    display: inline-block;
+    vertical-align: -10%;
+    font-size: 0.8em;
+  }
+
   margin-left: 4.5em;
   input {
     font-size: 0.75em;
-  }
-
-  [md-icon-button] {
-    margin-top: 14px;
   }
 
   md-icon {

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -50,6 +50,28 @@ describe('ToolbarComponent', () => {
     expect(authService.requireAuth).toHaveBeenCalled();
   });
 
+  it('should render lab name or input', () => {
+    let lab = Object.assign({}, testLab);
+    // lab user id and user id have to be equal
+    lab.user_id = 'some unique id';
+
+    component.context = new LabExecutionContext(lab);
+    component.lab = lab;
+    fixture.detectChanges();
+
+    let nameSpan = fixture.debugElement.query(By.css('.ml-toolbar__lab-name span'));
+
+    expect(nameSpan).toBeDefined();
+    expect(nameSpan.nativeElement.textContent).toEqual(lab.name);
+
+    let editButton = fixture.debugElement.query(By.css('.ml-toolbar__lab-name button'));
+    editButton.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    let nameInput = fixture.debugElement.query(By.css('.ml-toolbar__lab-name input'));
+    expect(nameInput).toBeDefined();
+  });
+
   describe('Toolbar Actions', () => {
 
     it('should emit run action', () => {
@@ -82,6 +104,7 @@ describe('ToolbarComponent', () => {
 
     it('should emit save action', () => {
       let lab = Object.assign({}, testLab);
+      // lab user id and user id have to be equal
       lab.user_id = 'some unique id';
 
       component.context = new LabExecutionContext(lab);


### PR DESCRIPTION
As discussed in #44, this commit adds functionality to the already existing
edit button for the lab name in the toolbar.

Closes #44