### PR TITLE
feat: pick up messages from redirected output

### DIFF
--- a/src/app/models/output.ts
+++ b/src/app/models/output.ts
@@ -1,0 +1,13 @@
+export enum OutputKind {
+  Stdout,
+  Stderr,
+  ProcessFinished,
+  OutputRedirected
+}
+
+export interface OutputMessage {
+  id: string,
+  data: string,
+  kind: OutputKind,
+  timestamp: number
+}

--- a/src/app/rx.operators.ts
+++ b/src/app/rx.operators.ts
@@ -9,3 +9,4 @@ import 'rxjs/add/operator/publishLast';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/merge';


### PR DESCRIPTION
This is the first bit for #46 

With this change the client knows how to deal with an `OutputRedirected` message for his requested run. It simply picks up the messages from a different endpoint then.

Notice that this needs to be run against a corresponding server PR (not sent yet). Also note that we probably have to wipe all the existing data in the staging system because the data base model slightly changed (due to new enums).

**Notice that his change does NOT yet tell the client in advance that we have a cached run. It does however print a message into the output about it**