### PR TITLE
chore: allow everyone to use their own local config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ testem.log
 #System Files
 .DS_Store
 Thumbs.db
+
+# allow everyone to use their own local config
+/src/environments/environments.personal.ts

--- a/angular-cli.json
+++ b/angular-cli.json
@@ -29,6 +29,7 @@
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",
+        "personal": "environments/environment.personal.ts",
         "offline": "environments/environment.offline.ts",
         "prod": "environments/environment.prod.ts",
         "test": "environments/environment.test.ts"


### PR DESCRIPTION
We often need totally different local configs. With this change use can use `ng serve --env=local` together with a `environment.local.ts` which is excluded from version control.

I noticed something like this is needed since everyone may use his own firebase configs (I do :))