### PR TITLE
chore: introduce Lab class

### DIFF
--- a/src/app/lab-storage.service.ts
+++ b/src/app/lab-storage.service.ts
@@ -20,14 +20,14 @@ export class LabStorageService {
     return this.authService
       .requireAuthOnce()
       .map(user => {
-        return {
+        return new Lab({
           id: shortid.generate(),
           user_id: user.uid,
           name: lab ? `Fork of ${lab.name}` : 'Untitled',
           description: lab ? lab.description : '',
           tags: lab ? lab.tags: [],
           files: lab ? lab.files : [{ name: 'main.py', content: '' }]
-        };
+        });
       });
   }
 

--- a/src/app/models/lab.ts
+++ b/src/app/models/lab.ts
@@ -1,3 +1,4 @@
+import { User } from './user';
 export enum ExecutionStatus {
   Pristine,
   Running,
@@ -18,9 +19,69 @@ export interface LabTemplate {
   files: File[];
 }
 
-export interface Lab extends LabTemplate {
-  id: string;
-  user_id: string;
+export class Lab implements LabTemplate {
+
+  private _lab;
+
+  get id() {
+    return this._lab.id;
+  }
+
+  set id(id) {
+    this._lab.id = id;
+  }
+
+  get user_id() {
+    return this._lab.user_id;
+  }
+
+  set user_id(id) {
+    this._lab.user_id = id;
+  }
+
+  get name() {
+    return this._lab.name;
+  }
+
+  set name(name: string) {
+    this._lab.name = name;
+  }
+
+  get description() {
+    return this._lab.description;
+  }
+
+  set description(description: string) {
+    this._lab.description = description;
+  }
+
+  get tags() {
+    return this._lab.tags;
+  }
+
+  set tags(tags: string[]) {
+    this._lab.tags = tags;
+  }
+
+  get files() {
+    return this._lab.files;
+  }
+
+  set files(files: File[]) {
+    this._lab.files = files;
+  }
+
+  constructor(lab) {
+    this._lab = lab;
+  }
+
+  isOwnedBy(user: User) {
+    return this._lab.user_id === user.uid;
+  }
+
+  toJSON() {
+    return this._lab;
+  }
 }
 
 export class LabExecutionContext {

--- a/src/app/remote-lab-exec.service.ts
+++ b/src/app/remote-lab-exec.service.ts
@@ -34,9 +34,9 @@ export class RemoteLabExecService {
     }
 
     let id = `${Date.now()}-${shortid.generate()}`;
-    context.setData(lab, id);
+    context.setData(lab.toJSON(), id);
     context.status = ExecutionStatus.Running;
-    
+
     let output$ = this.authService
                     .requireAuthOnce()
                     .switchMap(login => {
@@ -57,7 +57,7 @@ export class RemoteLabExecService {
                     .map((snapshot:any) => snapshot.val())
                     .share();
 
-    // we create a stream that - based on a filter - will only ever start producing 
+    // we create a stream that - based on a filter - will only ever start producing
     // messages if the output was redirected
     let redirectedOutput$ = output$.filter(msg => msg.kind === OutputKind.OutputRedirected)
                                    .switchMap(msg => this._childAddedAsObservable(this.db.ref(`process_messages/${msg.data}`)))


### PR DESCRIPTION
This commit introduces a `Lab` class that provides integration APIs for
lab objects. This came up in #50.

However, @cburgdorf already implemented the core motivation (having a `isOwnedBy()` method) in https://github.com/machinelabs/machinelabs-client/commit/a848341304fa07bc893f184510f40f3b1bd79098 which is why this PR can also be closed if this particular implementation isn't needed anymore.

Just thought I'll leave this here so @machinelabs/glory-hackers can at least take a look.

Closes #49