### PR TITLE
feat(ui): introduce execution status component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { EditorViewComponent } from './editor-view/editor-view.component';
 import { AddFileDialogComponent } from './add-file-dialog/add-file-dialog.component';
 import { NavigationConfirmDialogComponent } from './navigation-confirm-dialog/navigation-confirm-dialog.component';
 import { FileTreeComponent } from './file-tree/file-tree.component';
+import { ExecutionStatusComponent } from './execution-status/execution-status.component';
 
 import { APP_ROUTES } from './app.routes';
 import { LabResolver } from './lab.resolver';
@@ -43,7 +44,8 @@ export function databaseFactory() {
     EditorViewComponent,
     AddFileDialogComponent,
     FileTreeComponent,
-    NavigationConfirmDialogComponent
+    NavigationConfirmDialogComponent,
+    ExecutionStatusComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/editor-view/editor-view.component.html
+++ b/src/app/editor-view/editor-view.component.html
@@ -38,12 +38,7 @@
         [checked]="true"
         (click)="sidenav.toggle()">File browser</md-slide-toggle>
       <div class="ml-footer__status">
-        <div *ngIf="context.isRunning()">
-          <md-progress-bar
-            color="accent"
-            [bufferValue]="0"
-            mode="indeterminate"></md-progress-bar>
-        </div>
+        <ml-execution-status [executionContext]="context"></ml-execution-status>
       </div>
       <div>
         <button disabled md-button md-raised-button md-primary class="elevated">Share</button>

--- a/src/app/editor-view/editor-view.component.scss
+++ b/src/app/editor-view/editor-view.component.scss
@@ -14,10 +14,10 @@ md-sidenav { width: 350px; }
 }
 
 .ml-footer__status {
-  width: 250px;
+  width: 500px;
+  height: 20px;
+  margin-right: 12em;
 }
-
-md-progress-bar { height: 3px; }
 
 .elevated {
   background-color: #2196f3;

--- a/src/app/execution-status/execution-status.component.html
+++ b/src/app/execution-status/execution-status.component.html
@@ -1,0 +1,16 @@
+<div fxLayout>
+  <div fxFlex [ngSwitch]="executionContext.status">
+    <span *ngSwitchCase="ExecutionStatus.Running" class="ml-status-message">Running...</span>
+    <span *ngSwitchCase="ExecutionStatus.Done" class="ml-status-message done"><md-icon>done</md-icon> Done</span>
+    <span *ngSwitchCase="ExecutionStatus.Stopped" class="ml-status-message stopped"><md-icon>info</md-icon> Stopped</span>
+    <span *ngSwitchCase="ExecutionStatus.Error" class="ml-status-message errored"><md-icon>highlight_off</md-icon> Errored</span>
+  </div>
+  <div fxFlex>
+    <md-progress-bar
+      *ngIf="executionContext.isRunning()"
+      color="accent"
+      [bufferValue]="0"
+      mode="indeterminate"></md-progress-bar>
+  </div>
+</div>
+

--- a/src/app/execution-status/execution-status.component.scss
+++ b/src/app/execution-status/execution-status.component.scss
@@ -1,0 +1,31 @@
+.ml-status-message {
+  display: inline-block;
+  line-height: 1.5em;
+  font-weight: 600;
+  color: #444;
+
+  md-icon {
+    font-size: 1.3em;
+    vertical-align: -20%;
+    height: 15px;
+    width: 15px;
+    font-weight: bold;
+  }
+
+  &.done {
+    md-icon { color: springgreen; }
+  }
+  &.stopped {
+    md-icon { color: #ffc107; }
+  }
+  &.errored {
+    md-icon { color: orangered; }
+  }
+}
+
+md-progress-bar {
+  height: 3px;
+  margin-top: 0.7em;
+}
+
+

--- a/src/app/execution-status/execution-status.component.spec.ts
+++ b/src/app/execution-status/execution-status.component.spec.ts
@@ -1,0 +1,63 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { ExecutionStatusComponent } from './execution-status.component';
+import { LabExecutionContext, ExecutionStatus } from '../models/lab';
+
+describe('ExecutionStatusComponent', () => {
+  let component: ExecutionStatusComponent;
+  let fixture: ComponentFixture<ExecutionStatusComponent>;
+  let context: LabExecutionContext;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ExecutionStatusComponent],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(ExecutionStatusComponent);
+    component = fixture.componentInstance;
+    context = new LabExecutionContext();
+
+    component.executionContext = context;
+    fixture.detectChanges();
+  });
+
+  it('shouldn\'t show any status if status is pristine ', () => {
+    let statusMessage = fixture.debugElement.query(By.css('.ml-status-message'));
+    expect(statusMessage).toBe(null);
+  });
+
+  it('should show status message based on status type', () => {
+    let statusMessage;
+
+    context.status = ExecutionStatus.Running;
+    fixture.detectChanges();
+    statusMessage = fixture.debugElement.query(By.css('.ml-status-message'));
+    expect(statusMessage.nativeElement.textContent).toContain('Running...');
+
+    context.status = ExecutionStatus.Done;
+    fixture.detectChanges();
+    statusMessage = fixture.debugElement.query(By.css('.ml-status-message'));
+    expect(statusMessage.nativeElement.textContent).toContain('Done');
+
+    context.status = ExecutionStatus.Stopped;
+    fixture.detectChanges();
+    statusMessage = fixture.debugElement.query(By.css('.ml-status-message'));
+    expect(statusMessage.nativeElement.textContent).toContain('Stopped');
+
+    context.status = ExecutionStatus.Error;
+    fixture.detectChanges();
+    statusMessage = fixture.debugElement.query(By.css('.ml-status-message'));
+    expect(statusMessage.nativeElement.textContent).toContain('Errored');
+  });
+
+  it('should render progress bar when lab is running', () => {
+    context.status = ExecutionStatus.Running;
+    fixture.detectChanges();
+
+    let progressBar = fixture.debugElement.query(By.css('md-progress-bar'));
+    expect(progressBar).toBeDefined();
+  });
+});

--- a/src/app/execution-status/execution-status.component.ts
+++ b/src/app/execution-status/execution-status.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { LabExecutionContext, ExecutionStatus } from '../models/lab';
+
+@Component({
+  selector: 'ml-execution-status',
+  templateUrl: './execution-status.component.html',
+  styleUrls: ['./execution-status.component.scss']
+})
+export class ExecutionStatusComponent {
+  @Input() executionContext: LabExecutionContext;
+  ExecutionStatus = ExecutionStatus;
+}


### PR DESCRIPTION
This commit adds a new component that takes care of rendering the correct
execution status message in the editor footer toolbar based on the lab's
execution context's status.