### PR TITLE
fix: suppress webpack warning during build

### DIFF
--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -20,7 +20,7 @@ export interface ToolbarAction {
 })
 export class ToolbarComponent implements OnInit {
 
-  @Input() lab: Lab;
+  @Input() lab = null as Lab;
 
   @Input() context: LabExecutionContext;
 


### PR DESCRIPTION
The warning described in #49 is very likely caused by either TypeScript,
or some TypeScript loader plugin for webpack as discussed in issues:

- https://github.com/angular/angular-cli/issues/2034
- https://github.com/webpack/webpack/issues/2977

Unfortunately, this isn't solved at any end yet, so we need to go with
this workaround.

Closes #49