### PR TITLE
fix(FileNameDialog): allow all file types

### DIFF
--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -137,7 +137,7 @@ export class EditorViewComponent implements OnInit {
     this.fileNameDialogRef = this.dialog.open(FileNameDialogComponent, {
       disableClose: false,
       data: {
-        fileName: file ? file.name.substring(0, file.name.indexOf('.py')) : ''
+        fileName: file ? file.name :  ''
       }
     });
 

--- a/src/app/file-name-dialog/file-name-dialog.component.spec.ts
+++ b/src/app/file-name-dialog/file-name-dialog.component.spec.ts
@@ -66,7 +66,7 @@ describe('FileNameDialogComponent', () => {
 
     component.form.setValue({ filename: testName });
     component.submit(component.form);
-    expect(dialogRef.close).toHaveBeenCalledWith(`${testName}.py`);
+    expect(dialogRef.close).toHaveBeenCalledWith(testName);
   });
 });
 

--- a/src/app/file-name-dialog/file-name-dialog.component.ts
+++ b/src/app/file-name-dialog/file-name-dialog.component.ts
@@ -7,7 +7,6 @@ import { MdDialogRef, MD_DIALOG_DATA } from '@angular/material';
   template: `
     <form [formGroup]="form" (ngSubmit)="submit(form)">
     <md-input-container>
-        <span md-suffix>.py</span>
         <input mdInput placeholder="File name" formControlName="filename">
         <md-hint *ngIf="!form.valid && !form.pristine" align="start">This field is required.</md-hint>
       </md-input-container>
@@ -37,6 +36,6 @@ export class FileNameDialogComponent implements OnInit {
   }
 
   submit(form) {
-    this.dialogRef.close(`${form.value.filename}.py`);
+    this.dialogRef.close(`${form.value.filename}`);
   }
 }


### PR DESCRIPTION
Previously, the file name has been suffixed with `.py` to ensure files are
always python files. This however, isn't always what a user wants. Sometimes,
we need `.csv` files to import data sets.

This commit removes the `.py` restriction.

Closes #67