### PR TITLE
feat: show hint when lab has a cached run

### DIFF
--- a/src/app/editor-toolbar/editor-toolbar.component.spec.ts
+++ b/src/app/editor-toolbar/editor-toolbar.component.spec.ts
@@ -27,7 +27,8 @@ let testLab = {
   name: 'Existing lab',
   description: '',
   tags: ['existing'],
-  files: []
+  files: [],
+  has_cached_run: false
 };
 
 let routerStub = {

--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -183,12 +183,16 @@ export class EditorViewComponent implements OnInit {
       });
   }
 
-  initLab(lab) {
+  initLab(lab: Lab) {
     this.lab = lab;
 
     // try query param file name first
     const file = this.lab.files.find(f => f.name === this.router.parseUrl(this.location.path(false)).queryParams.file);
 
     this.openFile(file || this.lab.files[0]);
+
+    if (lab.has_cached_run) {
+      this.run(lab);
+    }
   }
 }

--- a/src/app/firebase/db-ref-builder.ts
+++ b/src/app/firebase/db-ref-builder.ts
@@ -19,8 +19,12 @@ export class DbRefBuilder {
     return new ObservableDbRef(this.db.ref(`runs/${id}`));
   }
 
-  processMessageRef(id: string) {
-    return new ObservableDbRef(this.db.ref(`process_messages/${id}`));
+  processMessageRef(id: string, limitToLast = 0) {
+    if (limitToLast > 0) {
+      return new ObservableDbRef(this.db.ref(`process_messages/${id}`).limitToLast(limitToLast));
+    } else {
+      return new ObservableDbRef(this.db.ref(`process_messages/${id}`));
+    }
   }
 
   userLabsRef(id: string) {

--- a/src/app/lab-storage.service.spec.ts
+++ b/src/app/lab-storage.service.spec.ts
@@ -16,7 +16,8 @@ let testLab = {
   name: 'Existing lab',
   description: '',
   tags: ['existing'],
-  files: []
+  files: [],
+  has_cached_run: false
 };
 
 let authServiceStub = {
@@ -127,12 +128,17 @@ describe('LabStorageService', () => {
 
     it('should save lab using firebase.database.set()', (done) => {
 
+      let expectedLab = Object.assign({}, testLab, { user_id: 'some-id' });
+      // Since `has_cached_run` is only written by the server, the
+      // returned lab should actually not have this property
+      delete expectedLab.has_cached_run;
+
       labStorageService.saveLab(testLab).subscribe(lab => {
 
         labStorageService.getLab(testLab.id)
           .subscribe(_lab => {
             // The returned lab should have its user_id changed
-            expect(_lab).toEqual(Object.assign({}, testLab, { user_id: 'some-id' }));
+            expect(_lab).toEqual(expectedLab);
             done();
           });
       });

--- a/src/app/lab.resolver.spec.ts
+++ b/src/app/lab.resolver.spec.ts
@@ -41,7 +41,8 @@ describe('LabResolver', () => {
         name: 'New Lab',
         description: 'this is a new lab',
         tags: [],
-        files: []
+        files: [],
+        has_cached_run: false
       };
 
       let activatedRouteSnapshotStub =  new ActivatedRouteSnapshot();
@@ -63,7 +64,8 @@ describe('LabResolver', () => {
         name: 'New Lab',
         description: 'this is a new lab',
         tags: [],
-        files: []
+        files: [],
+        has_cached_run: false,
       };
 
       let activatedRouteSnapshotStub = new ActivatedRouteSnapshot();
@@ -86,7 +88,8 @@ describe('LabResolver', () => {
         name: 'New Lab',
         description: 'this is a new lab',
         tags: [],
-        files: []
+        files: [],
+        has_cached_run: false
       };
 
       let activatedRouteSnapshotStub = new ActivatedRouteSnapshot();
@@ -109,7 +112,8 @@ describe('LabResolver', () => {
         name: 'New Lab',
         description: 'this is a new lab',
         tags: [],
-        files: []
+        files: [],
+        has_cached_run: false
       };
 
       let activatedRouteSnapshotStub = new ActivatedRouteSnapshot();
@@ -132,7 +136,8 @@ describe('LabResolver', () => {
         name: 'New Lab',
         description: 'this is a new lab',
         tags: [],
-        files: []
+        files: [],
+        has_cached_run: false
       };
 
       let activatedRouteSnapshotStub = new ActivatedRouteSnapshot();

--- a/src/app/models/lab.ts
+++ b/src/app/models/lab.ts
@@ -21,6 +21,7 @@ export interface LabTemplate {
 export interface Lab extends LabTemplate {
   id: string;
   user_id: string;
+  has_cached_run: boolean;
 }
 
 export class LabExecutionContext {

--- a/src/app/remote-lab-exec.service.spec.ts
+++ b/src/app/remote-lab-exec.service.spec.ts
@@ -15,7 +15,8 @@ let testLab = {
   name: 'Existing lab',
   description: '',
   tags: ['existing'],
-  files: []
+  files: [],
+  has_cached_run: false
 };
 
 let context = new LabExecutionContext();


### PR DESCRIPTION
With this PR we show a hint when a lab has a cached run. Notice that the hint only works for future labs (or existing labs which are saved again).

The hint is poorly placed. I was fighting for hours to make it look nice. I gave up. Would love to get some help here.