### PR TITLE
refactor: make firebase requests more DRY

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { LabResolver } from './lab.resolver';
 
 import { environment } from '../environments/environment';
 import { DATABASE } from './app.tokens';
+import { DbRefBuilder } from './firebase/db-ref-builder';
 
 // We need to export this factory function to make AoT happy
 export function databaseFactory() {
@@ -61,6 +62,7 @@ export function databaseFactory() {
     RemoteLabExecService,
     LabStorageService,
     LabResolver,
+    DbRefBuilder,
     { provide: DATABASE, useFactory: databaseFactory },
     { provide: AuthService, useClass: environment.offline ? OfflineAuthService : FirebaseAuthService },
     { provide: LabTemplateService, useClass: InMemoryLabTemplateService }

--- a/src/app/firebase/db-ref-builder.ts
+++ b/src/app/firebase/db-ref-builder.ts
@@ -1,0 +1,21 @@
+import { Injectable, Inject } from '@angular/core';
+import { environment } from 'environments/environment';
+import { DATABASE } from 'app/app.tokens';
+import { ObservableDbRef } from './observable-db-ref'
+
+@Injectable()
+export class DbRefBuilder {
+  constructor(@Inject(DATABASE) private db) {}
+
+  labRef(id: string) {
+    return new ObservableDbRef(this.db.ref(`labs/${id}`));
+  }
+
+  runRef(id: string) {
+    return new ObservableDbRef(this.db.ref(`runs/${id}`));
+  }
+
+  processMessageRef(id: string) {
+    return new ObservableDbRef(this.db.ref(`process_messages/${id}`));
+  }
+}

--- a/src/app/firebase/observable-db-ref.ts
+++ b/src/app/firebase/observable-db-ref.ts
@@ -1,0 +1,27 @@
+import { Observable } from 'rxjs/Observable';
+
+export class ObservableDbRef {
+
+  ref: any;
+
+  constructor (ref: any) {
+    this.ref = ref;
+  }
+
+  once(eventType: string) {
+    return Observable.fromPromise(this.ref.once(eventType))
+  }
+
+  onceValue() {
+    return this.once('value');
+  }
+
+  set(data: any) {
+    return Observable.fromPromise(this.ref.set(data));
+  }
+
+  childAdded() {
+    return Observable.fromEventPattern(handler => this.ref.on('child_added', handler),
+                                       handler => this.ref.off('child_added', handler));
+  }
+}

--- a/src/app/lab-storage.service.spec.ts
+++ b/src/app/lab-storage.service.spec.ts
@@ -6,6 +6,7 @@ import { LabStorageService } from './lab-storage.service';
 import { LabTemplateService, InMemoryLabTemplateService, DEFAULT_LAB_TPL_ID } from './lab-template.service';
 import { AuthService } from './auth';
 import { DATABASE } from './app.tokens';
+import { DbRefBuilder } from './firebase/db-ref-builder';
 import { LAB_TEMPLATES } from './data/lab-templates';
 
 let testLab = {
@@ -43,7 +44,8 @@ describe('LabStorageService', () => {
         LabStorageService,
         { provide: LabTemplateService, useClass: InMemoryLabTemplateService },
         { provide: AuthService, useValue: authServiceStub },
-        { provide: DATABASE, useValue: databaseStub }
+        { provide: DATABASE, useValue: databaseStub },
+        DbRefBuilder
       ]
     });
 

--- a/src/app/remote-lab-exec.service.spec.ts
+++ b/src/app/remote-lab-exec.service.spec.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { RemoteLabExecService } from './remote-lab-exec.service';
 import { AuthService } from './auth';
 import { DATABASE } from './app.tokens';
+import { DbRefBuilder } from './firebase/db-ref-builder';
 import { LabExecutionContext, Lab } from './models/lab';
 import { OutputKind } from 'app/models/output';
 
@@ -45,7 +46,8 @@ describe('RemoteLabExecService', () => {
       providers: [
         RemoteLabExecService,
         { provide: AuthService, useValue: authServiceStub },
-        { provide: DATABASE, useValue: databaseStub }
+        { provide: DATABASE, useValue: databaseStub },
+        DbRefBuilder
       ]
     });
 


### PR DESCRIPTION
I felt like cleaning up our Firebase usage a bit. We have lots of in place `Observable.fromPromise` or `Observable.fromEventPattern`.

I had another (quick) look at AngularFire because I wanted to know if they have this. I felt reassured that we can live good without it and built small tuned abstractions like this one.

This introduces two new abstractions `ObservableDbRef` which wraps a traditional db ref but gives us an Observable API. And `DbRefBuilder` which builds `ObservableDbRef` instances based on method calls rather than strings.

@machinelabs/glory-hackers anyone?