### PR TITLE
chore: update Angular Material to 2.0.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/flex-layout": "^2.0.0-beta.1",
     "@angular/forms": "4.1.0-beta.0",
     "@angular/http": "4.1.0-beta.0",
-    "@angular/material": "^2.0.0-beta.2",
+    "@angular/material": "^2.0.0-beta.3",
     "@angular/platform-browser": "4.1.0-beta.0",
     "@angular/platform-browser-dynamic": "4.1.0-beta.0",
     "@angular/router": "4.1.0-beta.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,8 +6,9 @@ import { NgModule } from '@angular/core';
 import { HttpModule } from '@angular/http';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { MaterialModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
+
+import { MachineLabsMaterialModule } from './ml-material.module';
 
 import { RemoteLabExecService } from './remote-lab-exec.service';
 import { LabStorageService } from './lab-storage.service';
@@ -55,8 +56,8 @@ export function databaseFactory() {
     FormsModule,
     ReactiveFormsModule,
     FlexLayoutModule.forRoot(),
-    MaterialModule.forRoot(),
-    RouterModule.forRoot(APP_ROUTES)
+    RouterModule.forRoot(APP_ROUTES),
+    MachineLabsMaterialModule
   ],
   providers: [
     RemoteLabExecService,

--- a/src/app/ml-material.module.ts
+++ b/src/app/ml-material.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import {
+  MdDialogModule,
+  MdSnackBarModule,
+  MdInputModule,
+  MdProgressBarModule,
+  MdMenuModule,
+  MdIconModule,
+  MdSlideToggleModule,
+  MdSidenavModule,
+  MdToolbarModule,
+  MdButtonModule
+} from '@angular/material';
+
+@NgModule({
+  exports: [
+    MdDialogModule,
+    MdSnackBarModule,
+    MdInputModule,
+    MdProgressBarModule,
+    MdMenuModule,
+    MdIconModule,
+    MdSlideToggleModule,
+    MdSidenavModule,
+    MdToolbarModule,
+    MdButtonModule
+  ]
+})
+export class MachineLabsMaterialModule {}

--- a/src/app/toolbar/toolbar.component.spec.ts
+++ b/src/app/toolbar/toolbar.component.spec.ts
@@ -3,8 +3,8 @@ import { By } from '@angular/platform-browser';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MaterialModule } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
+import { MachineLabsMaterialModule } from '../ml-material.module';
 import { AuthService, dummyUser } from '../auth/';
 import { ToolbarComponent, ToolbarActionTypes } from './toolbar.component';
 import { LabExecutionContext, ExecutionStatus } from '../models/lab';
@@ -31,7 +31,7 @@ describe('ToolbarComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ToolbarComponent],
-      imports: [MaterialModule, CommonModule, FormsModule],
+      imports: [MachineLabsMaterialModule, CommonModule, FormsModule],
       providers: [{ provide: AuthService, useValue: authServiceStub }]
     })
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,4 @@
-@import '../node_modules/@angular/material/core/theming/prebuilt/deeppurple-amber.css';
+@import '../node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css';
 *,
 *::before,
 *::after {

--- a/src/test.ts
+++ b/src/test.ts
@@ -11,6 +11,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import './app/rx/rx.operators';
 
@@ -23,7 +24,7 @@ __karma__.loaded = function () {};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
+  [BrowserDynamicTestingModule, NoopAnimationsModule],
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,9 +102,9 @@
   version "4.1.0-beta.0"
   resolved "https://registry.yarnpkg.com/@angular/http/-/http-4.1.0-beta.0.tgz#953a2074dc8cbf16ac97e4f49fd57395d8e67b43"
 
-"@angular/material@^2.0.0-beta.2":
-  version "2.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@angular/material/-/material-2.0.0-beta.2.tgz#65ee8733990347b7518b7f42113e02e069dc109b"
+"@angular/material@^2.0.0-beta.3":
+  version "2.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@angular/material/-/material-2.0.0-beta.3.tgz#ec31dee61d7300ece28fee476852db236ded1e13"
 
 "@angular/platform-browser-dynamic@4.1.0-beta.0":
   version "4.1.0-beta.0"


### PR DESCRIPTION
As per this release, `MaterialModule` are deprecated. That's why this commit
also introduces a new `MachineLabsMaterialModule` as recommended in
https://github.com/angular/material2/blob/master/CHANGELOG.md#materialmodule.