### PR TITLE
feat(ux): make active file configurable via URL

### DIFF
--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -137,6 +137,10 @@ export class EditorViewComponent implements OnInit {
 
   openFile(file: File) {
     this.activeFile = file;
+    this.router.navigate(['.'], {
+      relativeTo: this.route,
+      queryParams: { file: file.name }
+    });
   }
 
   deleteFile(file: File) {
@@ -174,6 +178,10 @@ export class EditorViewComponent implements OnInit {
 
   initLab(lab) {
     this.lab = lab;
-    this.openFile(this.lab.files[0]);
+
+    // try query param file name first
+    const file = this.lab.files.find(f => f.name === this.router.parseUrl(this.location.path(false)).queryParams.file);
+
+    this.openFile(file || this.lab.files[0]);
   }
 }


### PR DESCRIPTION
This commits enables users to use the `?file` query params, to configure
which file is active when the lab is loaded.

In addition, ML will now automatically update the URL with the latest active
file whenever a file is selected. That's why, as of this commit, when a user
navigates to `/SJBJxfS3g`, ML will immediately update the URL to
`/SJBJxfS3g?file=main.py` unless there's a `file` query param given.

I'm also happy exploring different query param names. `file` might be a bit too ambiguous.

/cc @machinelabs/glory-hackers 