### PR TITLE
feat(Toolbar): show lab owner info

### DIFF
--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -4,7 +4,22 @@
 
     <div fxFlex class="ml-toolbar__lab-name">
       <span [class.hidden]="editing">{{lab.name}}</span>
-      <button *ngIf="userOwnsLab()" md-icon-button type="button" (click)="openEditLabDialog(lab)"><md-icon>edit</md-icon></button>
+
+      <ng-container *ngIf="userOwnsLab(); else userInfo">
+        <button md-icon-button type="button" (click)="openEditLabDialog(lab)"><md-icon>edit</md-icon></button>
+      </ng-container>
+
+      <ng-template #userInfo>
+        <span class="ml-toolbar__user-info">
+          <ng-container *ngIf="(labOwner | async); else anonymousUser; let user;">
+            Created by <img [src]="user.photoUrl"> {{user.displayName}}
+          </ng-container>
+        </span>
+      </ng-template>
+
+      <ng-template #anonymousUser>
+        Created by <md-icon>account_circle</md-icon> anonymous user
+      </ng-template>
     </div>
 
     <div fxLayout fxLayoutAlign="end">

--- a/src/app/toolbar/toolbar.component.scss
+++ b/src/app/toolbar/toolbar.component.scss
@@ -29,7 +29,7 @@
   > span {
     display: inline-block;
     vertical-align: -10%;
-    font-size: 0.8em;
+    font-size: 1em;
   }
 
   margin-left: 4.5em;
@@ -40,6 +40,25 @@
   md-icon {
     font-size: 1.4em;
   }
+
+  .ml-toolbar__user-info {
+    vertical-align: -5%;
+    font-size: 0.7em;
+    margin-left: 0.5em;
+
+    img {
+      border-radius: 50%;
+      width: 1.4em;
+      vertical-align: top;
+    }
+
+    md-icon {
+      vertical-align: -25%;
+      height: 19px;
+      width: 19px;
+    }
+  }
+
 }
 
 .ml-toolbar__cta-bar {

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
 import { MdSnackBar, MdDialogRef, MdDialog } from '@angular/material';
 import { EditLabDialogComponent } from '../edit-lab-dialog/edit-lab-dialog.component';
 import { Lab, LabExecutionContext } from '../models/lab';
@@ -29,6 +30,8 @@ export class ToolbarComponent implements OnInit {
 
   @Output() action = new EventEmitter<ToolbarAction>();
 
+  labOwner: Observable<User>;
+
   private user: User;
 
   ToolbarActionTypes = ToolbarActionTypes;
@@ -44,6 +47,8 @@ export class ToolbarComponent implements OnInit {
   ngOnInit() {
     this.userService.observeUserChanges()
                     .subscribe(user => this.user = user);
+
+    this.labOwner = this.userService.getUser(this.lab.user_id);
   }
 
   userOwnsLab () {


### PR DESCRIPTION
This commit now displays the creator of a lab in the toolbar. We determine the
user of a lab by using `UserService.getUser(id)`. Anonymous users aren't stored
in our firebase, which means in case of an anonymous user, it'll emit `null`.

That's why we can rely "blindly" on Angular's `*ngIf ... else ... ;` syntax.

Once #66 landed, the template should link to the user profile.

Closes #92