### PR TITLE
fix(LabResolver): fixes bug that resolver emits wrong object when lab…

### DIFF
--- a/src/app/lab.resolver.spec.ts
+++ b/src/app/lab.resolver.spec.ts
@@ -123,5 +123,28 @@ describe('LabResolver', () => {
         expect(lab).toEqual(existingLab);
       });
     });
+
+    it('should resolve with empty lab if labid is given but resolves to null (lab doesn\'t exist', () => {
+
+      let emptyLab: Lab = {
+        id: 'new-lab',
+        user_id: 'user-id',
+        name: 'New Lab',
+        description: 'this is a new lab',
+        tags: [],
+        files: []
+      };
+
+      let activatedRouteSnapshotStub = new ActivatedRouteSnapshot();
+      activatedRouteSnapshotStub.params = { labid: 'some-id' };
+
+      spyOn(labStorageService, 'getLab').and.returnValue(Observable.of(null));
+      spyOn(labStorageService, 'createLab').and.returnValue(Observable.of(emptyLab));
+
+      labResolver.resolve(activatedRouteSnapshotStub).subscribe(lab => {
+        expect(labStorageService.createLab).toHaveBeenCalled();
+        expect(lab).toEqual(emptyLab);
+      });
+    });
   });
 });

--- a/src/app/lab.resolver.ts
+++ b/src/app/lab.resolver.ts
@@ -18,7 +18,7 @@ export class LabResolver implements Resolve<Lab> {
       // a new empty lab if no lab with the given id exists.
       return this.labStorageService
                   .getLab(route.paramMap.get('labid'))
-                  .map(lab => lab ? lab : this.labStorageService.createLab());
+                  .switchMap(lab => lab ? Observable.of(lab) : this.labStorageService.createLab());
     }
 
     // If a template id is specified, create a lab from that template,


### PR DESCRIPTION
… doesn't exist

This commit fixes a regression introduced in https://github.com/machinelabs/machinelabs-client/commit/e29025e0fe56c0d328b149b01adc760401f9c4b4, where `LabResolver.resolve()`
resolves with a wrong object type when asking for a lab that doesn't exist (anymore).

@machinelabs/glory-hackers I wonder if we should show a notification that fetching the requested lab failed (or maybe even be concrete and tell the user that it doesn't exist anymore). Right now, we just silently give the user an empty lab instead and don't even update the URL.

The latter isn't a big problem because it gets updated automatically, once the user saves the lab, however semantically, I think we should have the side effects to show a notification + reroute to `/`.

Thoughts?