### PR TITLE
refactor(toolbar): more DRY and aligned with rest of code

### DIFF
--- a/src/app/editor-toolbar/editor-toolbar.component.html
+++ b/src/app/editor-toolbar/editor-toolbar.component.html
@@ -6,7 +6,7 @@
       <span [class.hidden]="editing">{{lab.name}}</span>
 
       <ng-container *ngIf="userOwnsLab(); else userInfo">
-        <button md-icon-button type="button" (click)="openEditLabDialog(lab)"><md-icon>edit</md-icon></button>
+        <button md-icon-button type="button" (click)="emitAction(EditorToolbarActionTypes.Edit, lab)"><md-icon>edit</md-icon></button>
       </ng-container>
 
       <ng-template #userInfo>

--- a/src/app/editor-toolbar/editor-toolbar.component.spec.ts
+++ b/src/app/editor-toolbar/editor-toolbar.component.spec.ts
@@ -99,28 +99,29 @@ describe('EditorToolbarComponent', () => {
     expect(nameSpan.nativeElement.textContent).toEqual(lab.name);
   });
 
-  it('should open edit lab dialog when edit button is clicked', (done) => {
-    // The user will be available in the next tick hence the setTimeout
-    setTimeout(_ => {
-      let lab = Object.assign({}, testLab);
-      // lab user id and user id have to be equal
-      lab.user_id = 'some unique id';
-
-      component.context = new LabExecutionContext(lab);
-      component.lab = lab;
-      fixture.detectChanges();
-
-      spyOn(component, 'openEditLabDialog');
-
-      let editButton = fixture.debugElement.query(By.css('.ml-toolbar__lab-name button'));
-      editButton.triggerEventHandler('click', null);
-
-      expect(component.openEditLabDialog).toHaveBeenCalledWith(lab);
-      done();
-    });
-  });
-
   describe('Toolbar Actions', () => {
+
+    it('should emit edit action', (done) => {
+      // The user will be available in the next tick hence the setTimeout
+      setTimeout(_ => {
+        let lab = Object.assign({}, testLab);
+        // lab user id and user id have to be equal
+        lab.user_id = 'some unique id';
+
+        component.context = new LabExecutionContext(lab);
+        component.lab = lab;
+        fixture.detectChanges();
+
+        let editButton = fixture.debugElement.query(By.css('.ml-toolbar__lab-name button'));
+
+        component.action.subscribe(action => {
+          expect(action.type).toBe(EditorToolbarActionTypes.Edit);
+        });
+
+        editButton.triggerEventHandler('click', null);
+        done();
+      });
+    });
 
     it('should emit run action', () => {
       let runButton = fixture.debugElement.queryAll(By.css('.ml-toolbar__cta-bar button'))[0];

--- a/src/app/editor-toolbar/editor-toolbar.component.ts
+++ b/src/app/editor-toolbar/editor-toolbar.component.ts
@@ -1,15 +1,13 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
-import { MdSnackBar, MdDialogRef, MdDialog } from '@angular/material';
-import { EditLabDialogComponent } from '../edit-lab-dialog/edit-lab-dialog.component';
 import { Lab, LabExecutionContext } from '../models/lab';
 import { User } from '../models/user';
 import { AuthService } from '../auth/auth.service';
 import { UserService } from '../user/user.service';
 
 export enum EditorToolbarActionTypes {
-  Run, Stop, Save, Fork, Create
+  Run, Stop, Save, Fork, Create, Edit
 }
 
 export interface EditorToolbarAction {
@@ -36,14 +34,10 @@ export class EditorToolbarComponent implements OnInit {
 
   EditorToolbarActionTypes = EditorToolbarActionTypes;
 
-  editLabDialogRef: MdDialogRef<EditLabDialogComponent>;
-
   constructor(private authService: AuthService,
               private userService: UserService,
               private router: Router,
-              private route: ActivatedRoute,
-              private dialog: MdDialog,
-              private snackBar: MdSnackBar) {}
+              private route: ActivatedRoute) {}
 
   ngOnInit() {
     this.userService.observeUserChanges()
@@ -58,24 +52,5 @@ export class EditorToolbarComponent implements OnInit {
 
   emitAction(action: EditorToolbarActionTypes, data?: any) {
     this.action.emit({ type: action, data });
-  }
-
-  openEditLabDialog(lab: Lab) {
-    this.editLabDialogRef = this.dialog.open(EditLabDialogComponent, {
-      disableClose: false,
-      data: {
-        lab: lab
-      }
-    });
-
-    this.editLabDialogRef.afterClosed()
-        .filter(_lab => _lab !== undefined)
-        .subscribe(_lab => {
-          this.snackBar.open('Lab saved', 'Dismiss', { duration: 3000 });
-          this.router.navigate(['.'], {
-            relativeTo: this.route,
-            queryParamsHandling: 'preserve'
-          });
-        });
   }
 }

--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -65,6 +65,7 @@ export class EditorViewComponent implements OnInit {
       case EditorToolbarActionTypes.Save: this.save(action.data); break;
       case EditorToolbarActionTypes.Fork: this.fork(action.data); break;
       case EditorToolbarActionTypes.Create: this.create(); break;
+      case EditorToolbarActionTypes.Edit: this.save(action.data, true); break;
     }
   }
 
@@ -111,17 +112,17 @@ export class EditorViewComponent implements OnInit {
   fork(lab: Lab) {
     this.labStorageService.createLab(lab).subscribe(_lab => {
       this.lab = _lab;
-      this.save(this.lab, true);
+      this.save(this.lab, true, 'Lab forked');
     });
   }
 
-  save(lab: Lab, forking = false) {
+  save(lab: Lab, showEditDialog = false, msg = 'Lab saved') {
     this.labStorageService.saveLab(lab).subscribe(() => {
       this.router.navigate([lab.id], {
         queryParamsHandling: 'preserve'
       });
 
-      if (forking) {
+      if (showEditDialog) {
         this.editLabDialogRef = this.dialog.open(EditLabDialogComponent, {
           disableClose: false,
           data: {
@@ -133,10 +134,10 @@ export class EditorViewComponent implements OnInit {
             .afterClosed()
             .subscribe(_lab => {
               this.lab = _lab;
-              this.notifySnackBar('Lab forked.');
+              this.notifySnackBar(msg);
             });
       } else {
-        this.notifySnackBar('Lab saved.');
+        this.notifySnackBar(msg);
       }
     });
   }


### PR DESCRIPTION
As a follow up to your comment here https://github.com/machinelabs/machinelabs-client/pull/104#discussion_r112810839 I took a closer look and found that the way the edit action is currently implemented doesn't align well with the rest of the architecture here.

The rest of the toolbar actions simply emit actions which the `EditorViewComponent` then takes care of executing. The edit button was an exception here but I don't see a good justification for that.

This refactoring fixes that.

On aside note. Our `save` method in the editor has become unfortunate (before and after this refactoring). In case the dialog is shown, we actually save twice. This code should be further improved.

That said, it's a bit tricky because if someone aborts the edit dialog we aren't saving. So currently, from the consumer side there is no way to tell if the edit dialog did already perform a save or not. I would recommend to make the edit dialog more dumb and perform saving in the calling code. But that needs further investigations.

@PascalPrecht care to review this?