### PR TITLE
fix: don't save twice when forking

### DIFF
--- a/src/app/edit-lab-dialog/edit-lab-dialog.component.html
+++ b/src/app/edit-lab-dialog/edit-lab-dialog.component.html
@@ -12,6 +12,6 @@
   </md-input-container>
   <div style="text-align: center;">
     <button md-button [disabled]="!form.valid" type="submit">Save</button>
-    <button md-button type="button" (click)="dialogRef.close()">Cancel</button>
+    <button md-button type="button" (click)="close(form.value, false)">Cancel</button>
   </div>
 </form>

--- a/src/app/edit-lab-dialog/edit-lab-dialog.component.spec.ts
+++ b/src/app/edit-lab-dialog/edit-lab-dialog.component.spec.ts
@@ -77,7 +77,7 @@ describe('EditLabDialogComponent', () => {
     expect(component.form.value.tags).toEqual(lab.tags.join(','));
   });
 
-  it('should save lab when submitting the form and close dialog', (done) => {
+  it('should close dialog with right params on submit', (done) => {
     let dialogRef = dialog.open(EditLabDialogComponent, {
       data: {
         lab: lab
@@ -89,13 +89,10 @@ describe('EditLabDialogComponent', () => {
     component = dialogRef.componentInstance;
     component.ngOnInit();
 
-    fbMock.data[`labs/${lab.id}`] = lab;
-
     component.form.value.name = 'foo';
     component.submit(component.form.value);
     setTimeout(_ => {
-      expect(fbMock.data[`labs/${lab.id}`].name).toEqual('foo');
-      expect(dialogRef.close).toHaveBeenCalledWith(component.lab);
+      expect(dialogRef.close).toHaveBeenCalledWith({ lab: component.lab, shouldSave: true});
       done();
     });
   });

--- a/src/app/edit-lab-dialog/edit-lab-dialog.component.ts
+++ b/src/app/edit-lab-dialog/edit-lab-dialog.component.ts
@@ -18,7 +18,6 @@ export class EditLabDialogComponent implements OnInit {
   constructor(
     private dialogRef: MdDialogRef<EditLabDialogComponent>,
     private formBuilder: FormBuilder,
-    private labStorageService: LabStorageService,
     @Inject(MD_DIALOG_DATA) private data: any
   ) { }
 
@@ -35,9 +34,10 @@ export class EditLabDialogComponent implements OnInit {
     this.lab.name = data.name;
     this.lab.description = data.description;
     this.lab.tags = data.tags.split(',').filter(tag => tag.trim() !== '');
+    this.close(this.lab, true);
+  }
 
-    this.labStorageService
-        .saveLab(this.lab)
-        .subscribe(_ => this.dialogRef.close(this.lab));
+  close(lab: Lab, shouldSave: boolean) {
+    this.dialogRef.close({ lab, shouldSave});
   }
 }


### PR DESCRIPTION
This refactors the code with the intend to
fix two bugs.

First bug:

If we fork, we directly save and then open
a edit dialog which may perform another save.

Since we allways show this dialog we can
delay the save operation until the user
is past the dialog

Second bug:

App crashes when user cancels edit action

This change makes the `EditLabDialog` dumb
in the sense that it does not perform the
actual save action anymore. Instead it will
provide enough information to the outside
world to detect if changes need to be saved
or not.

It then breaks up the code in the editor
to use the dialog in a more fine grained way.