### PR TITLE
feat(EditLabDialog): teach dialog component config object

### DIFF
--- a/src/app/edit-lab-dialog/edit-lab-dialog.component.html
+++ b/src/app/edit-lab-dialog/edit-lab-dialog.component.html
@@ -12,6 +12,6 @@
   </md-input-container>
   <div style="text-align: center;">
     <button md-button [disabled]="!form.valid" type="submit">Save</button>
-    <button md-button type="button" (click)="close(form.value, false)">Cancel</button>
+    <button md-button *ngIf="!data.options.hideCancelButton" type="button" (click)="close(form.value, false)">Cancel</button>
   </div>
 </form>

--- a/src/app/editor-view/editor-view.component.ts
+++ b/src/app/editor-view/editor-view.component.ts
@@ -18,6 +18,10 @@ enum TabIndex {
   Console
 }
 
+interface EditLabDialogOptions {
+  hideCancelButton: boolean;
+}
+
 @Component({
   selector: 'ml-editor-view',
   templateUrl: './editor-view.component.html',
@@ -112,12 +116,13 @@ export class EditorViewComponent implements OnInit {
   fork(lab: Lab) {
     this.labStorageService.createLab(lab).subscribe(createdLab => {
       this.lab = createdLab;
-      this.showEditDialog(createdLab)
-          .subscribe(info => {
-            // we allways need to save after forking but either the
-            // version from before the dialog or the one after
-            this.save(info.shouldSave ? info.lab : createdLab, 'Lab forked');
-          });
+      this.showEditDialog(createdLab, {
+        hideCancelButton: true
+      }).subscribe(info => {
+        // we allways need to save after forking but either the
+        // version from before the dialog or the one after
+        this.save(info.shouldSave ? info.lab : createdLab, 'Lab forked');
+      });
     });
   }
 
@@ -140,11 +145,14 @@ export class EditorViewComponent implements OnInit {
         });
   }
 
-  showEditDialog(lab: Lab) {
+  showEditDialog(lab: Lab, options: EditLabDialogOptions = {
+    hideCancelButton: false
+  }) {
     this.editLabDialogRef = this.dialog.open(EditLabDialogComponent, {
           disableClose: false,
           data: {
-            lab: lab
+            lab: lab,
+            options
           }
         });
 


### PR DESCRIPTION
This is to enable consumers of the component to configure e.g. the UI,
like hiding the cancel button as discussed in https://github.com/machinelabs/machinelabs-client/pull/106#issuecomment-296401676