### PR TITLE
fix(ui/ux): activate editor tab after new lab has been created

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -236,6 +236,7 @@ export class EditorViewComponent implements OnInit {
 
   initLab(lab: Lab) {
     this.lab = lab;
+    this.tabGroup.selectedIndex = TabIndex.Editor;
 
     // try query param file name first
     const file = this.lab.files.find(f => f.name === this.router.parseUrl(this.location.path(false)).queryParams.file);


### PR DESCRIPTION
Prior to this commit, when a user had the "Console" tab active (maybe viewing the
running output), and then created a new lab, ML created the new lab, updated
the browser URL but stayed in the "Console" tab.

This was confusing because it looked like one is still in the same lab as before,
especially because the old output is still shown (this still needs to be fixed)