### PR TITLE
feat: Introduce MessageKind.ExecutionStarted

### DIFF
--- a/src/app/lab-editor/remote-code-execution/remote-lab-exec.service.spec.ts
+++ b/src/app/lab-editor/remote-code-execution/remote-lab-exec.service.spec.ts
@@ -130,7 +130,7 @@ describe('RemoteLabExecService', () => {
                   expect(actualMessages).toEqual([
                     { kind: 0, data: 'some-text' },
                     { kind: 0, data: 'other-text' },
-                    { kind: 2, data: '' }
+                    { kind: 3, data: '' }
                   ]);
                 })
                 .subscribe();
@@ -164,7 +164,7 @@ describe('RemoteLabExecService', () => {
                 .do(data => actualMessages.push(data))
                 .finally(() => {
                   expect(actualMessages).toEqual([
-                    { kind: 4, data: 'not allowed' }
+                    { kind: 5, data: 'not allowed' }
                   ]);
                 })
                 .subscribe();
@@ -219,11 +219,11 @@ describe('RemoteLabExecService', () => {
                 .do(data => actualMessages.push(data))
                 .finally(() => {
                   expect(actualMessages).toEqual([
-                    { kind: 3, data: '2' },
+                    { kind: 4, data: '2' },
                     { kind: 1, data: 'This is a cached execution. You are looking at a truncated response.' },
                     { kind: 0, data: 'some-text' },
                     { kind: 0, data: 'other-text' },
-                    { kind: 2, data: '' }
+                    { kind: 3, data: '' }
                   ]);
                 })
                 .subscribe();

--- a/src/app/models/execution.ts
+++ b/src/app/models/execution.ts
@@ -21,6 +21,7 @@ export interface Execution {
 export enum MessageKind {
   Stdout,
   Stderr,
+  ExecutionStarted,
   ExecutionFinished,
   OutputRedirected,
   ExecutionRejected


### PR DESCRIPTION
This goes hand in hand with https://github.com/machinelabs/machinelabs-server/pull/52 to
sync the enum fields with the one from the server as mentioned in
https://github.com/machinelabs/machinelabs-server/pull/52#issuecomment-302020955