### PR TITLE
fix: access correct firebase node for `/labs`

### DIFF
--- a/src/app/firebase/db-ref-builder.ts
+++ b/src/app/firebase/db-ref-builder.ts
@@ -31,8 +31,8 @@ export class DbRefBuilder {
     }
   }
 
-  userLabsRef(id: string) {
-    return new ObservableDbRef(this.db.ref(`labs`).orderByChild('common/user_id').equalTo(id));
+  userLabsIdsRef(id: string) {
+    return new ObservableDbRef(this.db.ref(`user_labs/${id}`));
   }
 }
 

--- a/src/app/lab-storage.service.ts
+++ b/src/app/lab-storage.service.ts
@@ -60,10 +60,12 @@ export class LabStorageService {
   }
 
   getLabsFromUser(userId: string): Observable<Array<Lab>> {
-    return this.db.userLabsRef(userId)
+    return this.db.userLabsIdsRef(userId)
               .onceValue()
               .map((snapshot: any) => snapshot.val())
-              .map((labs) => Object.keys(labs || {}).map((key) => labs[key]));
+              .map(labIds => Object.keys(labIds || {}))
+              .map(labIds => labIds.map(labId => this.getLab(labId)))
+              .switchMap(labRefs => labRefs.length ? Observable.forkJoin(labRefs) : Observable.of([]));
   }
 
 }

--- a/src/app/rx/rx.operators.ts
+++ b/src/app/rx/rx.operators.ts
@@ -1,3 +1,4 @@
+import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/observable/fromEventPattern';
 import 'rxjs/add/observable/of';


### PR DESCRIPTION
With the latest database rules introduced in https://github.com/machinelabs/machinelabs-server/commit/357e7704a802f2fdc71fecea3215b0e57ac95199 the `/labs` node
is no longer readable.

This commit fixes the path in `DbRefBuilder.userLabsRef()` to access `/labs/${id}/common`
instead.

Fixes #139