### PR TITLE
fixes some flaws

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/src/app/lab-editor/editor-view/editor-view.component.html
@@ -52,7 +52,7 @@
         #executionMetadataSidebar
         class="ml-sidebar"
         >
-      <ml-execution-metadata [execution]="context.execution" [executer]="labExecuter | async"></ml-execution-metadata>
+      <ml-execution-metadata [execution]="context.execution$"></ml-execution-metadata>
     </md-sidenav>
   </md-sidenav-container>
   <ml-footer

--- a/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -60,9 +60,6 @@ export class EditorViewComponent implements OnInit {
 
   rejectionDialogRef: MdDialogRef<RejectionDialogComponent>;
 
-
-  labExecuter: Observable<User>;
-
   constructor (private rleService: RemoteLabExecService,
                private labStorageService: LabStorageService,
                private route: ActivatedRoute,
@@ -112,7 +109,6 @@ export class EditorViewComponent implements OnInit {
                       if (msg.kind === MessageKind.ExecutionFinished) {
                         this.context.clientExecutionState = ClientExecutionState.NotExecuting;
                         this.editorSnackbar.notifyExecutionFinished();
-                        this.labExecuter = this.userService.getUser(this.context.execution.user_id);
                       } else if (msg.kind === MessageKind.OutputRedirected) {
                         this.editorSnackbar.notifyCacheReplay(msg.data);
                       } else if (msg.kind === MessageKind.ExecutionRejected) {

--- a/src/app/lab-editor/execution-metadata/execution-metadata.component.html
+++ b/src/app/lab-editor/execution-metadata/execution-metadata.component.html
@@ -1,4 +1,4 @@
-<md-card class="ml-execution-metadata">
+<md-card class="ml-execution-metadata" *ngIf="execution | async as execution;">
   <h4 class="ml-execution-metadata-headline"><md-icon>info</md-icon> Execution status</h4>
   <md-card-content class="ml-execution-metadata-content">
     <table>
@@ -25,7 +25,7 @@
       <tr class="ml-execution-metadata-user-info">
         <td>Executed by:</td>
         <td>
-          <ng-container *ngIf="executer; else notAvailable">
+          <ng-container *ngIf="executer | async as executer; else notAvailable">
             <img [src]="executer.photoUrl"> <a title="{{executer.displayName}}'s profile" [routerLink]="['/user', executer.id]">{{executer.displayName}}</a>
           </ng-container>
         </td>

--- a/src/app/lab-editor/execution-metadata/execution-metadata.component.ts
+++ b/src/app/lab-editor/execution-metadata/execution-metadata.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { User } from '../../models/user';
 import { Execution } from '../../models/execution';
+import { UserService } from 'app/user/user.service';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
   selector: 'ml-execution-metadata',
@@ -8,6 +10,19 @@ import { Execution } from '../../models/execution';
   styleUrls: ['./execution-metadata.component.scss']
 })
 export class ExecutionMetadataComponent {
-  @Input() execution = null as Execution;
-  @Input() executer: User;
+  _execution: Observable<Execution>;
+  executer: Observable<User>;
+
+  constructor(private userService: UserService) {
+  }
+
+  @Input()
+  set execution (val: Observable<Execution>) {
+    this._execution = val;
+    this.executer = val.filter(e => !!e.user_id).switchMap(e => this.userService.getUser(e.user_id));
+  }
+
+  get execution () {
+    return this._execution;
+  }
 }

--- a/src/app/lab-editor/remote-code-execution/remote-lab-exec.service.ts
+++ b/src/app/lab-editor/remote-code-execution/remote-lab-exec.service.ts
@@ -36,7 +36,7 @@ export class RemoteLabExecService {
     }
 
     let id = `${Date.now()}-${shortid.generate()}`;
-    context.setData(lab, id);
+    context.resetData(lab, id);
 
     let contextUpdater = new ContextExecutionUpdater(this.db, context);
     let output$ = this.authService


### PR DESCRIPTION
There are a couple of problems with the way we currently display the execution meta data.

**First:**

![image](https://cloud.githubusercontent.com/assets/521109/26443691/bbe18614-4139-11e7-85d3-55e800a7e95a.png)

The dates are sometimes wrong. To reproduce, run a cached execution (maybe from several days ago), then right after that, run a new execution (try changing the epochs to a higher, odd number). You'll notice that dates mix as visible on the screenshot.

**Second:**

The executer was set only after the execution finished. That's really unfortunate timing because we know the executer from the very beginning (like, the same moment we know all the other properties) but it means it may not be visible for hours before the execution finishes.

https://github.com/machinelabs/machinelabs-client/blob/64cbad0fedcff45b67cd0062abb3e57d030c9176/src/app/lab-editor/editor-view/editor-view.component.ts#L115

**Third:**

The editor keeps a reference to the `labExecuter` for the sole purpose of fetching it and passing it to the meta data view. As we have an ongoing fight to reduce the LOC in the editor and improve cohesion, I think it is better to move that code into the meta data view.

**Fifth**

The code wasn't really up to the reactive nature of how the execution works underneath. The `Execution` is constantly updated while the execution is running but without an `Observable<Execution>` it's hard to leverage.