### PR TITLE
chore: add script to deploy to staging

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "staging": "machinelabs-a73cd"
+  }
+}

--- a/deployment/deploy_to_staging.js
+++ b/deployment/deploy_to_staging.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+const chalk = require('chalk');
+const execute = require('./execute')();
+
+console.log(chalk.green('Building app...'));
+execute('ng build --environment=prod');
+console.log(chalk.green('Deploying to staging...'));
+execute('firebase use staging');
+execute('firebase deploy');
+console.log(chalk.green('Everything live at staging.machinelabs.ai'));
+

--- a/deployment/execute.js
+++ b/deployment/execute.js
@@ -1,0 +1,20 @@
+const execSync = require('child_process').execSync;
+const chalk = require('chalk');
+const spawnOptions = { stdio: 'pipe' };
+
+const factory = (options = { displayErrors: false }) => {
+  return (cmd) => {
+    try {
+      let output = execSync(cmd, spawnOptions).toString();
+      console.log(output);
+      return output;
+    }
+    catch (e) {
+      if (options.displayErrors){
+        console.log(chalk.red(e)); 
+      }
+    }
+  };
+}
+
+module.exports = factory;

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,11 @@
+{
+  "hosting": {
+    "public": "dist",
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@angular/compiler-cli": "4.2.0-rc.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "6.0.60",
+    "chalk": "^1.1.3",
     "codelyzer": "2.0.0",
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "3.2.0",


### PR DESCRIPTION
This is adding a deploy script to deploy the app to our staging system. Notice that I setup the hosting in the same firebase project (`machinelabs-staging`) where db, cloud functions and security rules live. After our recent discussion I realized that we can't put the staging versions of blog and website their as well since we can only have one hosting project. However, I think if we can keep the staging versions of db, db rules, cloud functions and app in one project that would be worth doing (same with production).