### PR TITLE
feat: redirect users after login when displayName is undefined

### DIFF
--- a/src/app/toolbar/toolbar-menu/toolbar-menu.component.spec.ts
+++ b/src/app/toolbar/toolbar-menu/toolbar-menu.component.spec.ts
@@ -1,5 +1,6 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterTestingModule } from '@angular/router/testing';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
@@ -35,7 +36,8 @@ describe('ToolbarMenuComponent', () => {
       declarations: [ToolbarMenuComponent],
       imports: [
         MachineLabsMaterialModule,
-        CommonModule
+        CommonModule,
+        RouterTestingModule
       ],
       providers: [
         { provide: AuthService, useValue: authServiceStub },

--- a/src/app/toolbar/toolbar-menu/toolbar-menu.component.ts
+++ b/src/app/toolbar/toolbar-menu/toolbar-menu.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { MdSnackBar } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
 import { AuthService } from '../../auth/auth.service';
-import { UserService } from '../../user/user.service';
+import { UserService, PLACEHOLDER_USERNAME } from '../../user/user.service';
 import { User } from '../../models/user';
 
 @Component({
@@ -16,6 +17,7 @@ export class ToolbarMenuComponent implements OnInit {
 
   constructor(private authService: AuthService,
               private userService: UserService,
+              private router: Router,
               private snackBar: MdSnackBar) {}
 
   ngOnInit() {
@@ -26,6 +28,11 @@ export class ToolbarMenuComponent implements OnInit {
     this.authService.linkOrSignInWithGitHub()
                     .switchMap(loginUser => this.userService.createUserIfMissing())
                     .subscribe(user => {
+
+      if (user.displayName === PLACEHOLDER_USERNAME) {
+        this.router.navigate(['/user', user.id], { queryParams: { editing: true }});
+      }
+
       this.snackBar.open(`Logged in as ${user.displayName}`, 'Dismiss', { duration: 3000 });
     });
   }

--- a/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog-theme.scss
+++ b/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog-theme.scss
@@ -1,0 +1,17 @@
+@import '../../../../node_modules/@angular/material/theming';
+
+@mixin ml-edit-user-profile-dialog-theme($theme) {
+
+  $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
+  $background: map-get($theme, background);
+  $foreground: map-get($theme, foreground);
+  $light-blue: mat-palette($mat-light-blue);
+
+  .ml-edit-user-profile-dialog-no-name-message {
+    color: mat-color($light-blue, 800);
+    background-color: mat-color($light-blue, 100);
+  }
+}
+
+

--- a/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog.component.html
+++ b/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog.component.html
@@ -2,9 +2,13 @@
   <form [formGroup]="form" (ngSubmit)="submit(form.value)">
   <ml-dialog-content>
     <div fxLayout="column">
+      <p class="ml-edit-user-profile-dialog-no-name-message" *ngIf="form.get('displayName').errors?.placeholderName"><md-icon>info</md-icon> Seems like you don't have a username yet.</p>
       <md-input-container fxFlex>
         <input mdInput placeholder="Profile name" formControlName="displayName">
-        <md-hint *ngIf="!form.valid && form.get('displayName').errors" align="end">This field is required.</md-hint>
+        <md-hint *ngIf="!form.valid && form.get('displayName').errors.required" align="end">This field is required.</md-hint>
+        <md-hint *ngIf="data.showNoUsernameMessage">
+
+        </md-hint>
       </md-input-container>
       <md-input-container fxFlex>
         <textarea mdInput maxlength="200" placeholder="Tell us a little bit about you" formControlName="bio"></textarea>

--- a/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog.component.scss
+++ b/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog.component.scss
@@ -7,3 +7,11 @@ textarea {
   line-height: 1.4;
 }
 
+.ml-edit-user-profile-dialog-no-name-message {
+  border-radius: 0.2em;
+  padding: 1em;
+
+  md-icon {
+    vertical-align: -25%;
+  }
+}

--- a/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog.component.ts
+++ b/src/app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog.component.ts
@@ -1,8 +1,14 @@
 import { Component, OnInit, Inject } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, AbstractControl } from '@angular/forms';
 import { MD_DIALOG_DATA, MdDialogRef } from '@angular/material';
 
 import { User } from '../../models/user';
+import { PLACEHOLDER_USERNAME } from '../../user/user.service';
+
+
+function validateNoPlaceholderName(control: AbstractControl) {
+  return control.value !== PLACEHOLDER_USERNAME ? null : { placeholderName: true };
+}
 
 @Component({
   selector: 'ml-edit-user-profile-dialog',
@@ -23,7 +29,7 @@ export class EditUserProfileDialogComponent implements OnInit {
   ngOnInit() {
     this.user = this.data.user;
     this.form = this.formBuilder.group({
-      displayName: [this.user.displayName, Validators.required],
+      displayName: [this.user.displayName, [Validators.required, validateNoPlaceholderName]],
       bio: this.user.bio
     });
   }

--- a/src/app/user-profile/user-profile.component.ts
+++ b/src/app/user-profile/user-profile.component.ts
@@ -39,6 +39,14 @@ export class UserProfileComponent implements OnInit, OnDestroy {
                                         .observeUserChanges()
                                         .switchMap(_ => this.userService.isLoggedInUser(this.user.id))
                                         .subscribe(isLoggedIn => this.isAuthUser = isLoggedIn);
+
+    // Need to wrap this in a timeout, otherwise we're running into an
+    // ExpressionChangedAfterItHasBeenCheckedError.
+    setTimeout(() => {
+      if (this.route.snapshot.queryParamMap.get('editing') && this.isAuthUser) {
+        this.edit();
+      }
+    });
   }
 
   edit() {

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -5,6 +5,8 @@ import { LoginUser, User } from '../models/user';
 import { Observable } from 'rxjs/Observable';
 import { Lang } from '../util/lang';
 
+export const PLACEHOLDER_USERNAME = 'Unnamed User';
+
 @Injectable()
 export class UserService {
 
@@ -43,7 +45,7 @@ export class UserService {
   mapUserToLoginUser(fromUser: LoginUser): User {
     return {
       id: fromUser.uid,
-      displayName: this.getDisplayName(fromUser),
+      displayName: this.getDisplayName(fromUser) || PLACEHOLDER_USERNAME,
       email: fromUser.email,
       bio: '',
       isAnonymous: fromUser.isAnonymous,

--- a/src/ml-theme.scss
+++ b/src/ml-theme.scss
@@ -7,6 +7,7 @@
 @import 'app/lab-editor/panel/panel-theme.scss';
 @import 'app/lab-editor/file-tree/file-tree-theme.scss';
 @import 'app/user-profile/user-profile-theme.scss';
+@import 'app/user-profile/edit-user-profile-dialog/edit-user-profile-dialog-theme.scss';
 
 @include mat-core();
 
@@ -26,6 +27,7 @@ $ml-app-theme: mat-light-theme($ml-app-primary, $ml-app-accent, $ml-app-warn);
   @include ml-panel-theme($theme);
   @include ml-file-tree-theme($theme);
   @include ml-user-profile-theme($theme);
+  @include ml-edit-user-profile-dialog-theme($theme);
 }
 
 @include angular-material-theme($ml-app-theme);


### PR DESCRIPTION
As discussed in #99, it can happen that when a user logs in via GitHub
and there's no `displayName` in GitHub, that user also won't have a proper
`displayName` in MachineLabs either.

In addition, since recent database rules changes, the user can't even be
saved when the `displayName == null` anyways.

This commit does two things:

1. It ensures that if the gh `displayName` is `null`, the `displayName` in ML becomes `Unnamed User`
2. If that's the case, the user gets redirected to her profile so she can change her `displayName` to
  a proper one

Closes #99