### PR TITLE
chore: remove description and tags from editor view

### DIFF
--- a/e2e/editor-view/editor-view.e2e-spec.ts
+++ b/e2e/editor-view/editor-view.e2e-spec.ts
@@ -36,14 +36,6 @@ describe('Editor-View Component', function() {
       expect(editorView.getFileName(0)).toContain('main.py');
     });
 
-    it('should display the current lab description', () => {
-      expect(editorView.labDescription).toEqual('');
-    });
-
-    it('should display the current lab tags', () => {
-      expect(editorView.labTags).toEqual([]);
-    });
-
     it('should allow users to edit file names', () => {
       let fileIndex = 0;
 

--- a/e2e/editor-view/editor-view.page-object.ts
+++ b/e2e/editor-view/editor-view.page-object.ts
@@ -43,22 +43,6 @@ export class EditorViewPageObject {
     return this.tabs.filter((elem, index) => elem.getText().then(text => text === label));
   }
 
-
-  /**
-   * SIDENAV
-   */
-  get labDescription(): promise.Promise<string> {
-    return element(by.css('.ml-lab-description')).getText();
-  }
-
-  get labTags(): promise.Promise<Array<string>> {
-    return element(by.tagName('ml-tag-list'))
-              .all(by.tagName('md-chip'))
-              .reduce((acc: Array<string>, elem: ElementFinder) => {
-                return elem.getText().then((text: string) => acc.concat(text));
-              }, []);
-  }
-
   getFileByIndex(index: number): ElementFinder {
     return this.fileList.get(index);
   }

--- a/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/src/app/lab-editor/editor-view/editor-view.component.html
@@ -39,10 +39,6 @@
             (removeFile)="deleteFile($event)"
             (editFile)="openFileNameDialog($event)"
             (addFile)="openFileNameDialog()"></ml-file-tree>
-          <ml-panel-title>Description</ml-panel-title>
-          <p class="ml-lab-description">{{lab.description}}</p>
-          <ml-panel-title>Tags</ml-panel-title>
-          <ml-tag-list [tags]="lab.tags"></ml-tag-list>
         </ml-panel>
         <div class="ml-editor-view-editor-wrapper">
           <ml-ace-editor

--- a/src/app/lab-editor/editor-view/editor-view.component.scss
+++ b/src/app/lab-editor/editor-view/editor-view.component.scss
@@ -40,12 +40,3 @@ md-sidenav-container {
   flex: 1;
 }
 
-.ml-lab-description {
-  padding: 1.2em 2em;
-  margin: 0;
-  font-size: 0.9em;
-  line-height: 1.2em;
-}
-
-ml-tag-list { padding: 0em 2em 2em; }
-


### PR DESCRIPTION
There are a couple of reasons why removing them from editor view makes sense:

1. Right now they don't have a proper place. Semantically, both description and
   tags don't belong in below the file-tree component.
2. It doesn't really make sense to introduce another view inside the editor for
   that data.
3. We're more likely to embrace readme files in labs in the future, which are much
   more suited for longer descriptions.

Description and tags metadata is still going to be used in the user profile and
other views of ML where this information useful.