### PR TITLE
fix: make URL updates without navigation more robust

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { Location } from '@angular/common';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Router, ActivatedRoute, UrlSerializer } from '@angular/router';
 import { MdDialog, MdDialogRef, MdSnackBar, MdTabGroup, MdSidenav } from '@angular/material';
 import { AceEditorComponent } from '../ace-editor/ace-editor.component';
 import { FileNameDialogComponent } from '../file-name-dialog/file-name-dialog.component';
@@ -80,6 +80,7 @@ export class EditorViewComponent implements OnInit {
                private dialog: MdDialog,
                private editorSnackbar: EditorSnackbarService,
                private location: Location,
+               private urlSerializer: UrlSerializer,
                private router: Router,
                private userService: UserService) {
   }
@@ -233,7 +234,7 @@ export class EditorViewComponent implements OnInit {
       .filter(confirmed => confirmed)
       .switchMap(_ => this.labStorageService.createLab())
       .subscribe(lab => {
-        this.location.go(`/?tpl=${BLANK_LAB_TPL_ID}`);
+        this.goToLab();
         this.initLab(lab);
         this.editorSnackbar.notifyLabCreated();
       });
@@ -247,7 +248,8 @@ export class EditorViewComponent implements OnInit {
     this.activeFile = file;
     this.router.navigate(['.'], {
       relativeTo: this.route,
-      queryParams: { file: file.name }
+      queryParams: { file: file.name },
+      queryParamsHandling: 'merge'
     });
   }
 
@@ -302,10 +304,12 @@ export class EditorViewComponent implements OnInit {
     }
   }
 
-  private goToLab(lab) {
-    let fullPath = this.location.path();
-    let queryString = fullPath.substr(fullPath.indexOf('?'), fullPath.length);
-    let path = fullPath.substr(0, fullPath.indexOf('?'));
-    this.location.go(`${path}/${lab.id}${queryString}`);
+  private goToLab(lab?: Lab) {
+    this.location.go(this.urlSerializer.serialize(
+      this.router.createUrlTree([`${lab ? lab.id : '.'}`], {
+        queryParamsHandling: 'merge',
+        relativeTo: this.route
+      })
+    ));
   }
 }


### PR DESCRIPTION
The function to update the editors url without actually performing a navigation
introduced in https://github.com/machinelabs/machinelabs-client/commit/1b2cec44aea3c569077298c7fca74365b80b7fe5
is going to be refactored to much more robust `UrlSerializer` APIs provided
by Angular.

We're now using exactly the same mechanisms that the router uses to update
the url just that we don't schedule a navigation.

I couldn't reproduce #204, however I think this should now be fixed with this
implementation.

Notice that this commit also fixes a bug that whenever a user selected a file in
the file browser, the url was update with the `file` query parameter but it also
erased all other existing ones. This can be a problem when we start implementing
query parameters to select executions of a lab.

Fixes #204