### PR TITLE
feat: add basic service worker support

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -35,7 +35,8 @@
         "prod": "environments/environment.prod.ts",
         "test": "environments/environment.test.ts",
         "e2e": "environments/environment.e2e.ts"
-      }
+      },
+      "serviceWorker": "true"
     }
   ],
   "addons": [],

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser": "4.2.2",
     "@angular/platform-browser-dynamic": "4.2.2",
     "@angular/router": "4.2.2",
+    "@angular/service-worker": "1.0.0-beta.15",
     "@types/js-yaml": "^3.5.30",
     "@types/shortid": "0.0.28",
     "@types/socket.io-client": "1.4.29",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,6 +138,13 @@
   dependencies:
     tslib "^1.7.1"
 
+"@angular/service-worker@1.0.0-beta.15":
+  version "1.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@angular/service-worker/-/service-worker-1.0.0-beta.15.tgz#222fab4570ba1e77c56b54181aa55d26d4f60cc9"
+  dependencies:
+    base64-js "^1.1.2"
+    jshashes "^1.0.5"
+
 "@angular/tsc-wrapped@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.2.2.tgz#094da1514849a0847f9cb5184e0ceb16fc194457"
@@ -537,7 +544,7 @@ base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
 
@@ -845,14 +852,14 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
 
 clap@^1.0.9:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.0.tgz#59c90fe3e137104746ff19469a27a634ff68c857"
   dependencies:
     chalk "^1.1.3"
 
 clean-css@4.1.x:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.3.tgz#07cfe8980edb20d455ddc23aadcf1e04c6e509ce"
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.4.tgz#eec8811db27457e0078d8ca921fa81b72fa82bf4"
   dependencies:
     source-map "0.5.x"
 
@@ -2357,8 +2364,8 @@ iconv-lite@0.4.15:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 iconv-lite@^0.4.17:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -2829,6 +2836,10 @@ jsesc@^1.3.0:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+jshashes@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/jshashes/-/jshashes-1.0.6.tgz#b04eb4ae8f9987b2d3ce00a6337c120543949bfd"
 
 json-loader@^0.5.4:
   version "0.5.4"
@@ -5318,8 +5329,8 @@ uglify-js@3.0.x:
     source-map "~0.5.1"
 
 uglify-js@^2.6, uglify-js@^2.8.5:
-  version "2.8.28"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.28.tgz#e335032df9bb20dcb918f164589d5af47f38834a"
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"


### PR DESCRIPTION
This commit adds Angular's Service Worker capabilities to MachineLabs when building
the app for production. Here's how it goes:

- build app for production using `ng build --prod`
- inspect `/dist` folder a notive `ngsw.manifest.json`
- `index.html` has a couple new script added to it now

Basically what happens is that CLI automatically adds a manifest file for us which
is going to be consumed by the service worker, which is also automatically added
to the production builder (in addition to a script that registers the SW).

If you serve the generated dist check the servie worker panel in the devtools,
you'll see that a SW has been installed. Reload the app and check the network
panel. Static assets are now served from cache.

And yes, all this by just saying `serviceWorker: true`.