### PR TITLE
fix: show information when no execution data is available

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/src/app/lab-editor/editor-view/editor-view.component.html
@@ -66,11 +66,21 @@
           #executionMetadataSidebar
           class="ml-sidebar"
           >
-        <ml-execution-metadata
-            *ngFor="let execution of executions | async"
-            [execution]="execution"
-            (listen)=listen($event)>
-        </ml-execution-metadata>
+        <ng-container *ngIf="executions | async as executions; else noExecutionMessage">
+          <ml-execution-metadata
+              *ngFor="let execution of executions"
+              [execution]="execution"
+              (listen)="listen($event)">
+          </ml-execution-metadata>
+        </ng-container>
+
+        <ng-template #noExecutionMessage>
+          <div class="ml-execution-metadata-no-execution-message">
+            <md-icon class="ml-execution-metadata-no-execution-message-icon">info_outline</md-icon>
+            <h4 class="ml-execution-metadata-no-execution-message-headline">No information available</h4>
+            <p class="ml-execution-metadata-no-execution-message-text">Execute your lab and its execution data will show up here.</p>
+          </div>
+        </ng-template>
       </md-sidenav>
     </md-sidenav-container>
   </div>

--- a/src/app/lab-editor/editor-view/editor-view.component.scss
+++ b/src/app/lab-editor/editor-view/editor-view.component.scss
@@ -40,3 +40,26 @@ md-sidenav-container {
   flex: 1;
 }
 
+.ml-execution-metadata-no-execution-message {
+  margin-top: 7em;
+  margin-left: 2.5em;
+  margin-right: 2.5em;
+  text-align: center;
+}
+
+.ml-execution-metadata-no-execution-message-icon {
+  font-size: 7em;
+  height: initial;
+  width: initial;
+  margin-bottom: 0.2em;
+}
+
+.ml-execution-metadata-no-execution-message-headline {
+  margin: 0;
+  font-size: 1.5em;
+  font-weight: 400;
+}
+
+.ml-execution-metadata-no-execution-message-text {
+  line-height: 1.4;
+}

--- a/src/app/lab-editor/execution-metadata/execution-metadata.component.scss
+++ b/src/app/lab-editor/execution-metadata/execution-metadata.component.scss
@@ -46,26 +46,3 @@
   }
 }
 
-.ml-execution-metadata-no-execution-message {
-  margin-top: 7em;
-  margin-left: 2.5em;
-  margin-right: 2.5em;
-  text-align: center;
-}
-
-.ml-execution-metadata-no-execution-message-icon {
-  font-size: 7em;
-  height: initial;
-  width: initial;
-  margin-bottom: 0.2em;
-}
-
-.ml-execution-metadata-no-execution-message-headline {
-  margin: 0;
-  font-size: 1.5em;
-  font-weight: 400;
-}
-
-.ml-execution-metadata-no-execution-message-text {
-  line-height: 1.4;
-}


### PR DESCRIPTION
Since https://github.com/machinelabs/machinelabs-client/commit/b4c136ba61299ee48d11bed59dbefb7180acc7db
it's possible that there's no available execution metadata for a lab, which
causes the metadata sidebar to be empty.

This commit ensures that a message is shown when no execution metadata
information is available.

Fixes: #230