### PR TITLE
fix: show stop and restart button only if user owns execution

### DIFF
--- a/src/app/lab-editor/execution-metadata/execution-metadata.component.html
+++ b/src/app/lab-editor/execution-metadata/execution-metadata.component.html
@@ -36,8 +36,8 @@
     </div>
     <div class="ml-execution-metadata-cta-bar">
       <button md-button (click)="listen.emit(execution)">View</button>
-      <button md-button (click)="stop(execution)" *ngIf="execution.status === ExecutionStatus.Executing">Stop</button>
-      <button md-button (click)="restart.emit(execution)" *ngIf="execution.status != ExecutionStatus.Executing && execution.status != ExecutionStatus.Pristine">Restart</button>
+      <button md-button (click)="stop(execution)" *ngIf="execution.status === ExecutionStatus.Executing && userService.userOwnsExecution(user, execution)">Stop</button>
+      <button md-button (click)="restart.emit(execution)" *ngIf="execution.status != ExecutionStatus.Executing && execution.status != ExecutionStatus.Pristine && userService.userOwnsExecution(user, execution)">Restart</button>
     </div>
   </div>
 </ng-container>

--- a/src/app/lab-editor/execution-metadata/execution-metadata.component.ts
+++ b/src/app/lab-editor/execution-metadata/execution-metadata.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input, EventEmitter, Output } from '@angular/core';
 import { User } from '../../models/user';
 import { Execution } from '../../models/execution';
 import { UserService } from 'app/user/user.service';
@@ -14,16 +14,28 @@ import 'rxjs/add/operator/switchMap';
   templateUrl: './execution-metadata.component.html',
   styleUrls: ['./execution-metadata.component.scss']
 })
-export class ExecutionMetadataComponent {
+export class ExecutionMetadataComponent implements OnInit, OnDestroy {
+
   _execution: Observable<Execution>;
+
   executer: Observable<User>;
+
+  user: User;
+
   ExecutionStatus = ExecutionStatus;
+
+  private userSubscription;
 
   @Output() listen = new EventEmitter<Execution>();
   @Output() restart = new EventEmitter<Execution>();
 
-  constructor(private userService: UserService,
+  constructor(public userService: UserService,
               private rleService: RemoteLabExecService) {
+  }
+
+  ngOnInit() {
+    this.userSubscription = this.userService.observeUserChanges()
+                    .subscribe(user => this.user = user);
   }
 
   @Input()
@@ -38,5 +50,9 @@ export class ExecutionMetadataComponent {
 
   stop(execution: Execution) {
     this.rleService.stop(execution.id);
+  }
+
+  ngOnDestroy() {
+    this.userSubscription.unsubscribe();
   }
 }

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AuthService } from 'app/auth';
 import { DbRefBuilder } from '../firebase/db-ref-builder';
 import { LoginUser, User } from '../models/user';
+import { Execution } from '../models/execution';
 import { Observable } from 'rxjs/Observable';
 import { Lang } from '../util/lang';
 
@@ -88,5 +89,9 @@ export class UserService {
 
   userOwnsLab(user: User, lab) {
     return lab && user && lab.user_id === user.id;
+  }
+
+  userOwnsExecution(user: User, execution: Execution) {
+    return user && user.id === execution.user_id;
   }
 }


### PR DESCRIPTION
Actually we want to check if the user owns the lab. However, that
would've required a bigger refactoring as the user id isn't stored
on a lab that's attached to an execution.

That's why we simply check if the user owns the execution. This should
be enough because only owners of a lab can execute it.

Closes #216