### PR TITLE
fix: ensure latest execution if broken execution id is given

### DIFF
--- a/src/app/lab-editor/lab-editor.module.ts
+++ b/src/app/lab-editor/lab-editor.module.ts
@@ -8,7 +8,7 @@ import { SharedModule } from '../shared/shared.module';
 import { ToolbarModule } from '../toolbar/toolbar.module';
 
 import { LabResolver } from './lab.resolver';
-import { HasExecutionGuard } from './has-execution.guard';
+import { HasValidExecutionGuard } from './has-valid-execution.guard';
 import { ROUTES } from './lab-editor.routes';
 
 import { RemoteLabExecService } from './remote-code-execution/remote-lab-exec.service';
@@ -68,7 +68,7 @@ import { ExecutionListComponent } from './execution-list/execution-list.componen
   ],
   providers: [
     LabResolver,
-    HasExecutionGuard,
+    HasValidExecutionGuard,
     RemoteLabExecService,
     EditorSnackbarService,
     LabConfigService,

--- a/src/app/lab-editor/lab-editor.routes.ts
+++ b/src/app/lab-editor/lab-editor.routes.ts
@@ -1,7 +1,7 @@
 import { Routes } from '@angular/router';
 import { EditorViewComponent } from './editor-view/editor-view.component';
 import { LabResolver } from './lab.resolver';
-import { HasExecutionGuard } from './has-execution.guard';
+import { HasValidExecutionGuard } from './has-valid-execution.guard';
 
 
 export const ROUTES: Routes = [
@@ -18,13 +18,14 @@ export const ROUTES: Routes = [
     resolve: {
       lab: LabResolver
     },
-    canActivate: [HasExecutionGuard]
+    canActivate: [HasValidExecutionGuard]
   },
   {
     path: ':id/:executionId',
     component: EditorViewComponent,
     resolve: {
       lab: LabResolver
-    }
+    },
+    canActivate: [HasValidExecutionGuard]
   }
 ];

--- a/src/app/lab-execution.service.ts
+++ b/src/app/lab-execution.service.ts
@@ -35,13 +35,19 @@ export class LabExecutionService {
       }, []);
   }
 
-
   getLatestExecutionIdForLab(id: string) {
     return this.authService
       .requireAuthOnce()
       .switchMap(_ => this.db.labExecutionsRef(id).limitToLast(1).onceValue())
       .map((snapshot: any) => snapshot.val())
       .map(value => value ? Object.keys(value)[0] : null);
+  }
+
+  executionExists(id: string) {
+    return this.authService
+      .requireAuth()
+      .switchMap(_ => this.db.executionRef(id).onceValue())
+      .map((snapshot: any) => !!snapshot.val());
   }
 }
 


### PR DESCRIPTION
Prior to this commit a user could go to:

```
/editor/some-lab-id/foo <-- this execution id doesn't exist
```

We want to make sure that in such a case we simply look for the latest execution.
This is done by this commit.

Fixes #263