### PR TITLE
fix: don't listen to latest execution in list when initializing lab

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -358,12 +358,10 @@ export class EditorViewComponent implements OnInit {
         .take(1)
         .map(executions => executions.length > 0 ? executions[0] : null)
         .filter(obsExecution => !!obsExecution)
-        .switchMap(obsExecution => obsExecution)
         .subscribe(execution => {
           // Only attach to an existing execution if the user did not do it by themself
           if (this.clientExecutionState === ClientExecutionState.NotExecuting) {
             this.selectTab(TabIndex.Console);
-            this.listen(execution);
           }
         });
 


### PR DESCRIPTION
A regression was introduced in https://github.com/machinelabs/machinelabs-client/commit/48e2d31ce8fad8f738d7e6552544460a835ecb07
that `rleService.listen()` was executed twice in lab initialization.
First with the execution id provided via URL (the one determined by
`HasValidExecutionGuard`), and then a second time in `initLab()` where
we, up until now, simply picked the first execution of the list and
listened to it as well, which essentially caused the output to be
overwritten while the correct execution is selected.