### PR TITLE
Christoph/chore/client executon state

### DIFF
--- a/src/app/lab-editor/editor-toolbar/editor-toolbar.component.spec.ts
+++ b/src/app/lab-editor/editor-toolbar/editor-toolbar.component.spec.ts
@@ -9,7 +9,7 @@ import { MachineLabsMaterialModule } from '../../ml-material.module';
 import { SharedModule } from '../../shared/shared.module';
 import { AuthService, dummyUser } from '../../auth/';
 import { EditorToolbarComponent, EditorToolbarActionTypes } from './editor-toolbar.component';
-import { ExecutionStatus, ClientExecutionState } from '../../models/execution';
+import { ExecutionStatus } from '../../models/execution';
 import { UserService } from '../../user/user.service';
 import { DbRefBuilder } from '../../firebase/db-ref-builder';
 import { DATABASE } from '../../app.tokens';

--- a/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -24,7 +24,6 @@ import {
   Execution,
   ExecutionMessage,
   MessageKind,
-  ClientExecutionState,
   ExecutionRejectionInfo,
   ExecutionRejectionReason,
   ExecutionWrapper
@@ -72,7 +71,6 @@ export class EditorViewComponent implements OnInit {
 
   executions: Observable<Array<Observable<Execution>>>;
 
-  clientExecutionState = ClientExecutionState.NotExecuting;
 
   sidebarToggled = false;
 
@@ -206,7 +204,6 @@ export class EditorViewComponent implements OnInit {
     this.output = messages$
                     .do(msg => {
                       if (msg.kind === MessageKind.ExecutionFinished) {
-                        this.clientExecutionState = ClientExecutionState.NotExecuting;
                         this.editorSnackbar.notifyExecutionFinished();
                       }
                     })
@@ -361,11 +358,10 @@ export class EditorViewComponent implements OnInit {
         .take(1)
         .map(executions => executions.length > 0 ? executions[0] : null)
         .filter(obsExecution => !!obsExecution)
+        .switchMap(obsExecution => obsExecution)
         .subscribe(execution => {
-          // Only attach to an existing execution if the user did not do it by themself
-          if (this.clientExecutionState === ClientExecutionState.NotExecuting) {
-            this.selectTab(TabIndex.Console);
-          }
+          this.selectTab(TabIndex.Console);
+          this.listen(execution);
         });
 
     this.selectTab(TabIndex.Editor);

--- a/src/app/models/execution.ts
+++ b/src/app/models/execution.ts
@@ -9,10 +9,6 @@ export enum ExecutionStatus {
   Failed
 }
 
-export enum ClientExecutionState {
-  Executing,
-  NotExecuting
-}
 
 export interface Execution {
   id?: string;

--- a/src/app/models/lab.ts
+++ b/src/app/models/lab.ts
@@ -1,4 +1,4 @@
-import { Execution, ExecutionStatus, ClientExecutionState } from './execution';
+import { Execution, ExecutionStatus } from './execution';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 


### PR DESCRIPTION
Removes the `ClientExecutionState` as it wasn't used anymore. Or better, it was never set to `Executing` which makes it pointless.