### PR TITLE
feat: adds new rejection dialogs

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -172,7 +172,7 @@ export class EditorViewComponent implements OnInit {
                   if (info.rejection.reason === ExecutionRejectionReason.InvalidConfig) {
                     this.editorSnackbar.notifyInvalidConfig();
                   } else {
-                    this.openRejectionDialog();
+                    this.openRejectionDialog(info.rejection.reason);
                   }
                 }
               });
@@ -346,8 +346,10 @@ export class EditorViewComponent implements OnInit {
       });
   }
 
-  openRejectionDialog() {
-    this.rejectionDialogRef = this.dialog.open(RejectionDialogComponent);
+  openRejectionDialog(rejectionReason: ExecutionRejectionReason) {
+    this.rejectionDialogRef = this.dialog.open(RejectionDialogComponent, {
+      data: { rejectionReason }
+    });
   }
 
   initLab(lab: Lab) {

--- a/src/app/lab-editor/rejection-dialog/rejection-dialog.component.html
+++ b/src/app/lab-editor/rejection-dialog/rejection-dialog.component.html
@@ -1,8 +1,33 @@
-<ml-dialog-header>Request <strong>your beta invite</strong></ml-dialog-header>
-<ml-dialog-content>
-  <p>Hoppla, looks like you aren't part of our <strong>private beta</strong> yet!</p>
-  <p>Without an invite you can only view existing executions. To run your own experiments you have to request an invite.</p>
-</ml-dialog-content>
-<ml-dialog-cta-bar>
-  <a md-button href="http://get.machinelabs.ai" title="Request an invite for our private beta!" target="_blank"><md-icon>send</md-icon> Request invite</a>
-</ml-dialog-cta-bar>
+<ng-container [ngSwitch]="data.rejectionReason">
+  <ng-container *ngSwitchCase="ExecutionRejectionReason.NoPlan || ExecutionRejectionReason.NoAnonymous">
+    <ml-dialog-header>Request <strong>your beta invite</strong></ml-dialog-header>
+    <ml-dialog-content>
+      <p>Hoppla, looks like you aren't part of our <strong>private beta</strong> yet!</p>
+      <p>Without an invite you can only view existing executions. To run your own experiments you have to request an invite.</p>
+    </ml-dialog-content>
+    <ml-dialog-cta-bar>
+      <a md-button href="http://get.machinelabs.ai" title="Request an invite for our private beta!" target="_blank"><md-icon>send</md-icon> Request invite</a>
+    </ml-dialog-cta-bar>
+  </ng-container>
+  <ng-container *ngSwitchCase="ExecutionRejectionReason.OutOfCredits">
+    <ml-dialog-header>Out of free monthly credits</ml-dialog-header>
+    <ml-dialog-content>
+      <p>Woah, you've been active! Looks like you've used up all your <strong>free</strong> monthly credits!</p>
+      <p>Next month you'll be able to launch executions as usual again.</p>
+      <p>In the future you'll get to choose a paid plan that allows unlimited executions.</p>
+    </ml-dialog-content>
+    <ml-dialog-cta-bar>
+      <button md-button [md-dialog-close]="true">Ok</button>
+    </ml-dialog-cta-bar>
+  </ng-container>
+  <ng-container *ngSwitchDefault>
+    <ml-dialog-header>Hoppla, something went wrong</ml-dialog-header>
+    <ml-dialog-content>
+      <p>Something went terrible wrong and honestly, we have no idea what exactly.</p>
+      <p>Please shoot us an email to <strong><a href="mailto:support@machinelabs.ai">support@machinelabs.ai</a></strong> if the problem continues</p>
+    </ml-dialog-content>
+    <ml-dialog-cta-bar>
+      <button md-button [md-dialog-close]="true">Ok</button>
+    </ml-dialog-cta-bar>
+  </ng-container>
+</ng-container>

--- a/src/app/lab-editor/rejection-dialog/rejection-dialog.component.ts
+++ b/src/app/lab-editor/rejection-dialog/rejection-dialog.component.ts
@@ -1,8 +1,13 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, Inject } from '@angular/core';
+import { MD_DIALOG_DATA } from '@angular/material';
+import { ExecutionRejectionReason } from '../../models/execution';
 
 @Component({
   selector: 'ml-rejection-dialog',
   templateUrl: './rejection-dialog.component.html',
   styleUrls: ['./rejection-dialog.component.scss']
 })
-export class RejectionDialogComponent {}
+export class RejectionDialogComponent {
+  ExecutionRejectionReason = ExecutionRejectionReason
+  constructor(@Inject(MD_DIALOG_DATA) public data: any) {}
+}

--- a/src/app/models/execution.ts
+++ b/src/app/models/execution.ts
@@ -43,7 +43,8 @@ export interface ExecutionMessage {
 export enum ExecutionRejectionReason {
   NoAnonymous,
   NoPlan,
-  InvalidConfig
+  InvalidConfig,
+  OutOfCredits
 }
 
 export class ExecutionRejectionInfo {


### PR DESCRIPTION
This adds two new rejection dialogs
but reuses the existing RejectionDialog
to keep things concise and KISS.

1. A dialog for OutOfCredit rejections
2. A default dialog for all other rejections

The second dialog is particular useful
to at least bring up something when new
rejections got added to the server but
where not yet implemented properly in
the client.

Notice that the server will add this rejection reason once https://github.com/machinelabs/machinelabs-server/pull/101 lands. However it is totally safe to merge this PR before the feature lands in the server.