### PR TITLE
refactor: consume execution manually without relying on route change

### DIFF
--- a/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/src/app/lab-editor/editor-view/editor-view.component.html
@@ -60,6 +60,7 @@
             [executions]="executions"
             [activeId]="activeExecutionId"
             (restart)="run($event.lab)"
+            (view)="listenAndUpdateUrl($event)"
             ></ml-execution-list>
         </ng-container>
 

--- a/src/app/lab-editor/execution-list/execution-list.component.html
+++ b/src/app/lab-editor/execution-list/execution-list.component.html
@@ -41,13 +41,7 @@
           </div>
         </div>
         <div class="ml-execution-panel-cta-bar">
-          <a [routerLink]="['../', execution.id]"
-            queryParamsHandling="merge"
-            title="View this execution"
-            *ngIf="execution.id !== activeId"
-            md-button>
-            View
-          </a>
+          <button md-button (click)="view.emit(execution)" *ngIf="execution.id !== activeId">View</button>
           <button md-button (click)="stop(execution)" *ngIf="execution.status === ExecutionStatus.Executing && userService.userOwnsExecution(user, execution)">Stop</button>
           <button md-button (click)="restart.emit(execution)" *ngIf="execution.status != ExecutionStatus.Executing && execution.status != ExecutionStatus.Pristine && userService.userOwnsExecution(user, execution)">Restart</button>
 

--- a/src/app/lab-editor/execution-list/execution-list.component.ts
+++ b/src/app/lab-editor/execution-list/execution-list.component.ts
@@ -25,6 +25,8 @@ export class ExecutionListComponent implements OnInit, OnDestroy {
 
   @Output() restart = new EventEmitter<Execution>();
 
+  @Output() view = new EventEmitter<Execution>();
+
   ExecutionStatus = ExecutionStatus;
 
   user: User;

--- a/src/app/util/location-helper.ts
+++ b/src/app/util/location-helper.ts
@@ -16,4 +16,11 @@ export class LocationHelper {
       this.router.createUrlTree(urlSegments, options)
     ));
   }
+
+  updateQueryParams(path: string, params) {
+    const currentUrlTree = this.router.parseUrl(path);
+    currentUrlTree.queryParams = Object.assign({}, currentUrlTree.queryParams, params);
+
+    this.location.go(this.urlSerializer.serialize(currentUrlTree))
+  }
 }


### PR DESCRIPTION
This commit goes back to using manual URL updates without triggering route
changes and therefore also doesn't rely on route parameter changes anymore.

One of the reasons we're doing this is because the previous architecture
introduced ugly side effects like flickering in the UI when running a lab
for the first time, due to route changes.

There's also a change in `EditorViewComponent`'s `listen()` API. Instead of
taking an entire `Execution` it only takes an execution id, as it makes the
method more reusable throughout the code base.