### PR TITLE
uiux: change order of execution action buttons for better UX

### DIFF
--- a/src/app/lab-editor/execution-list/execution-list.component.html
+++ b/src/app/lab-editor/execution-list/execution-list.component.html
@@ -56,8 +56,8 @@
           </button>
 
           <md-menu #menu="mdMenu" yPosition="above">
-            <button md-menu-item (click)="showEditExecutionModal(execution)" *ngIf="userService.userOwnsExecution(user, execution)">Edit</button>
             <button md-menu-item (click)="remove(execution)" *ngIf="execution.status != ExecutionStatus.Executing && execution.id != activeId && userService.userOwnsExecution(user, execution)">Remove</button>
+            <button md-menu-item (click)="showEditExecutionModal(execution)" *ngIf="userService.userOwnsExecution(user, execution)">Edit</button>
   </md-menu>
         </div>
       </md-expansion-panel>


### PR DESCRIPTION
Since the menu position is "above", the "remove" button is the first one
reachable when opening the menu. People could accidently remove executions
like that.