### PR TITLE
feat: show restore message when viewing different version of lab than latest saved state

### DIFF
--- a/src/app/lab-editor/editor-snackbar.service.ts
+++ b/src/app/lab-editor/editor-snackbar.service.ts
@@ -18,6 +18,10 @@ export class EditorSnackbarService {
     this.notify('New lab created');
   }
 
+  notifyLabRestored() {
+    this.notify('Lab restored');
+  }
+
   notifyLabUpdated() {
     this.notify('Lab updated');
   }

--- a/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/src/app/lab-editor/editor-view/editor-view.component.html
@@ -17,6 +17,8 @@
          md-tab-link
          (click)="selectTab(TabIndex.Console)"
          [active]="selectedTab == TabIndex.Console">Console</a>
+
+      <p *ngIf="showRestoreMessage" class="ml-editor-restore-message">You're viewing an older version of this lab. Want to restore latest version? <button md-button color="primary" (click)="restoreLab()">Restore</button></p>
     </nav>
   </div>
   <div class="ml-editor-view-layout-main">

--- a/src/app/lab-editor/editor-view/editor-view.component.scss
+++ b/src/app/lab-editor/editor-view/editor-view.component.scss
@@ -40,6 +40,18 @@ md-sidenav-container {
   flex: 1;
 }
 
+.ml-editor-restore-message {
+  position: absolute;
+  right: 1em;
+  top: 0.5em;
+  margin: 0;
+  font-size: 0.9em;
+
+  button {
+    margin-left: 0.2em;
+  }
+}
+
 .ml-execution-metadata-no-execution-message {
   margin-top: 7em;
   margin-left: 2.5em;

--- a/src/app/lab-editor/lab-editor.routes.ts
+++ b/src/app/lab-editor/lab-editor.routes.ts
@@ -19,7 +19,6 @@ export const ROUTES: Routes = [
     resolve: {
       lab: LabResolver
     },
-    canActivate: [HasValidExecutionGuard],
     canDeactivate: [HasRunningExecutionGuard]
   },
   {

--- a/src/app/util/directory.ts
+++ b/src/app/util/directory.ts
@@ -1,0 +1,8 @@
+import { File } from '../models/lab';
+
+export class Directory {
+
+  static isSameDirectory(a: File[], b: File[]) {
+    return JSON.stringify(a) !== JSON.stringify(b);
+  }
+}


### PR DESCRIPTION
~~Still missing the part to not automatically redirect. Also should be rebased on latest changes that do not use `router.navigate()` anymore~~