### PR TITLE
fix: disable service worker support

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -36,7 +36,7 @@
         "test": "environments/environment.test.ts",
         "e2e": "environments/environment.e2e.ts"
       },
-      "serviceWorker": "true"
+      "serviceWorker": "false"
     }
   ],
   "addons": [],


### PR DESCRIPTION
Disabling service worker support until
we have a proper update strategy. Currently
with server worker support enabled, users
are forced to clear the cache manually in
order to get updates which basically
breaks the deployment.