### PR TITLE
uiux: remove duration info when lab is running

### DIFF
--- a/src/app/user-profile/user-profile.component.html
+++ b/src/app/user-profile/user-profile.component.html
@@ -52,7 +52,7 @@
                       <md-icon *ngSwitchCase="ExecutionStatus.Failed">block</md-icon>
                     </ng-container>
                     {{ execution.name || '#' + execution.id }}
-                    <span><md-icon>schedule</md-icon> Ran for {{execution.started_at | distanceInWordsStrict: execution.finished_at}} about {{execution.started_at | distanceInWordsToNow}} ago</span>
+                    <span *ngIf="execution.status != ExecutionStatus.Executing"><md-icon>schedule</md-icon> Ran for {{execution.started_at | distanceInWordsStrict: execution.finished_at}} about {{execution.started_at | distanceInWordsToNow}} ago</span>
                   </md-card>
                 </a>
               </ng-container>


### PR DESCRIPTION
This will be changed again once we've fleshed out all the information
we want to show in the execution view.

Right now this is breaking when a lab is executing because
`finished_at` is null

So this is really just a temporary hot fix.