### PR TITLE
feat(server): give everyone 72 free hours per month

### DIFF
--- a/server/src/statistics/usage-statistic.service.ts
+++ b/server/src/statistics/usage-statistic.service.ts
@@ -6,10 +6,8 @@ import { DbRefBuilder } from '../ml-firebase/db-ref-builder';
 import { CostCalculator } from './cost-calculator';
 import { UsageStatistic } from './usage-statistic';
 
-// This is ridiculous low now so that we hopefully hit it soon
-// in our daily usage. Should be rather something like 100 once
-// we launch private beta. Also, should be read from the db.
-const FREE_MONTHLY_USD_CREDIT = 1;
+// Give everyone 72 hours per month
+const FREE_MONTHLY_COMPUTATION_SECONDS = 72 * 60 * 60;
 
 export class UsageStatisticService {
 
@@ -34,11 +32,10 @@ export class UsageStatisticService {
       .map(snapshot => snapshot.val())
       .filter(execution => execution !== null);
 
-      return this.costCalculator.calc(executions$)
-                         .map(costReport => ({
-                           costReport: costReport,
-                           creditsLeft: FREE_MONTHLY_USD_CREDIT - costReport.totalCost
-                         }));
+    return this.costCalculator.calc(executions$)
+                              .map(costReport => ({
+                                  costReport: costReport,
+                                  secondsLeft: FREE_MONTHLY_COMPUTATION_SECONDS - costReport.totalSeconds
+                                }));
   }
-
 }

--- a/server/src/statistics/usage-statistic.ts
+++ b/server/src/statistics/usage-statistic.ts
@@ -2,5 +2,5 @@ import { CostReport } from './cost-report';
 
 export interface UsageStatistic {
   costReport: CostReport;
-  creditsLeft: number;
+  secondsLeft: number;
 }

--- a/server/src/validation/rules/has-credits-left.ts
+++ b/server/src/validation/rules/has-credits-left.ts
@@ -15,7 +15,7 @@ export class HasCreditsLeftRule implements ValidationRule {
 
     return resolves
       .get(UsageStatisticResolver)
-      .map(statistic => !statistic || statistic.creditsLeft <= 0 ?
+      .map(statistic => !statistic || statistic.secondsLeft <= 0 ?
         new ExecutionRejectionInfo(ExecutionRejectionReason.OutOfCredits, 'User is out of credits') :
         true);
   }


### PR DESCRIPTION
Since we decide to go with CPU only for now, it
is simpler to just define the free credits in
terms of ours.

We decided to give everyone beta user 72 free
hours per month.