### PR TITLE
fix(rleService): make sure timeout does not keep stream alive

### DIFF
--- a/client/src/app/editor/remote-code-execution/remote-lab-exec.service.ts
+++ b/client/src/app/editor/remote-code-execution/remote-lab-exec.service.ts
@@ -102,6 +102,9 @@ export class RemoteLabExecService {
         rejection: null
       })
       .merge(timeout$)
+      // The API is expected to complete after two notifications but the
+      // merge of the $timeout would prevent that.
+      .take(2)
       .catch((e) => {
         let error = e instanceof TimeoutError ? e : new RateLimitError(id, 'Rate limit exceeded');
         console.error(error);


### PR DESCRIPTION
The timeout should only come into effect when the
two expected messages did not arrive timely.

This was previously not the case so that it
errored even after the happy case.

Fixes 359