### PR TITLE
perf(database): add index on invocations

### DIFF
--- a/firebase/database.rules.bolt
+++ b/firebase/database.rules.bolt
@@ -169,7 +169,7 @@ path /invocations/{id} {
 }
 
 path /invocations {
-  index() { ['server/id'] }
+  index() { ['server/id', 'server/ahlem/timestamp', 'server/hainholz/timestamp'] }
 }
 
 path /executions/{id}/common is Execution {

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -157,7 +157,9 @@
         ".write": "auth.uid == 'cloud-fn-assign-server'"
       },
       ".indexOn": [
-        "server/id"
+        "server/id",
+        "server/ahlem/timestamp",
+        "server/hainholz/timestamp"
       ]
     },
     "executions": {


### PR DESCRIPTION
While this is hardcoding two server names
into our rules, I think the technical debt
is small enough that the benefit is higher
than the cost.