### PR TITLE
fix(EditorView): open execution list when lab has executions

### DIFF
--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -322,9 +322,8 @@ export class EditorViewComponent implements OnInit {
   private initExecutionList() {
     this.executions = this.editorService.observeExecutionsForLab(this.lab);
     this.executions
-        .take(1)
-        .map(executions => executions.length > 0 ? executions[0] : null)
-        .filter(obsExecution => !!obsExecution)
+        .take(2)
+        .filter(executions => !!executions.length)
         .do(_ => this.openExecutionList())
         .subscribe(_ => {
           if (this.activeExecutionId) {


### PR DESCRIPTION
As part of https://github.com/machinelabs/machinelabs/commit/c57cb64107a7d37604554c1af5b7a7a06bbf1ba7 we introduced a regression that the lab execution list didn't
open anymore automatically when visiting a lab that actually has executions.

This was due to `editorService.observableExecutionsForLab()` always emitting an
empty array as first value.

This commit ensures that we're waiting for the first two values instead so we
can operator on actual data.

Fixes #365