### PR TITLE
refactor: change restore behavour and wording

### DIFF
--- a/client/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.html
@@ -18,7 +18,7 @@
           (click)="selectTab(TabIndex.Console)"
           [active]="editorService.consoleTabActive()">Console</a>
 
-        <p *ngIf="showRestoreMessage" class="ml-editor-restore-message">You're viewing an older version of this lab. Want to restore latest version? <button md-button color="primary" (click)="restoreLab()">Restore</button></p>
+        <p *ngIf="activeExecutionId" class="ml-editor-restore-message">Restore saved lab directory <button md-button color="primary" (click)="restoreLab()">Restore</button></p>
       </div>
     </ml-editor-layout-nav-bar>
   </ml-editor-layout-header>

--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -86,8 +86,6 @@ export class EditorViewComponent implements OnInit {
 
   navigationConfirmDialogRef: MdDialogRef<NavigationConfirmDialogComponent>;
 
-  showRestoreMessage = false;
-
   sidebarToggled = false;
 
   @ViewChild('executionMetadataSidebar') executionMetadataSidebar: MdSidenav;
@@ -221,7 +219,6 @@ export class EditorViewComponent implements OnInit {
       .take(1)
       .subscribe(execution => {
         this.slimLoadingBarService.complete();
-        this.showRestoreMessage = Directory.isSameDirectory(execution.lab.directory, this.latestLab.directory);
         this.editorService.initDirectory(execution.lab.directory);
       });
 
@@ -237,7 +234,6 @@ export class EditorViewComponent implements OnInit {
       .subscribe(info => {
         this.outputPanel.clear();
         this.activeExecutionId = null;
-        this.showRestoreMessage = false;
         // we allways need to save after forking but either the
         // version from before the dialog or the one after
         this.save(info.shouldSave ? info.lab : this.lab, 'Lab forked', true);
@@ -341,7 +337,6 @@ export class EditorViewComponent implements OnInit {
       queryParamsHandling: 'merge'
     });
     this.editorService.initDirectory(this.latestLab.directory);
-    this.showRestoreMessage = false;
 
     setTimeout(() => {
       this.executionMetadataSidebar.close();


### PR DESCRIPTION
This simplifies the rules of when a saved lab can be restored.
The rule now is: when an execution is selected, regardless of whether it's
different from that last saved version of the lab, people get the option
to restore that last saved version.

Closes #330