### PR TITLE
fix: fix production build by moving autotrack to vendor scripts

### DIFF
--- a/client/angular-cli.json
+++ b/client/angular-cli.json
@@ -25,7 +25,8 @@
         "../node_modules/ace-builds/src-noconflict/theme-github.js",
         "../node_modules/ace-builds/src-noconflict/theme-terminal.js",
         "../node_modules/ace-builds/src-noconflict/mode-python.js",
-        "../node_modules/ace-builds/src-noconflict/mode-sh.js"
+        "../node_modules/ace-builds/src-noconflict/mode-sh.js",
+        "../node_modules/autotrack/autotrack.js"
       ],
       "environmentSource": "environments/environment.ts",
       "environments": {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,4 @@
 import './polyfills.ts';
-import 'autotrack';
-import 'autotrack/lib/plugins/url-change-tracker';
 
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';


### PR DESCRIPTION
Turns out autotrack was already minified which causes our production build
to fail. This commit removes imports to autotrack and adds autotrack as a
vendor script to CLIs config. That's where it should be anyways.

Also it turned out autotrack already comes with all plugins included, there's
not need to import/embedded urlChangeTracker explicitely.

In the future we might want to revisit this and have a custom build for autotrack
that doesn't always include all plugins (which is the case right now).

However filesize is still kind of low (8kb gzipped) so I'm going to
postpone that for now.