### PR TITLE
feat: allow server to be disabled

### DIFF
--- a/firebase/database.rules.bolt
+++ b/firebase/database.rules.bolt
@@ -127,6 +127,7 @@ type Server {
   id: String,
   hardware_type: String,
   name: String
+  disabled: Boolean
 }
 
 type RateProof {

--- a/firebase/database.rules.json
+++ b/firebase/database.rules.json
@@ -304,7 +304,7 @@
     "servers": {
       ".read": "auth.uid == 'execution-server' || auth.uid == 'cloud-fn-assign-server'",
       "$id": {
-        ".validate": "newData.hasChildren(['id', 'hardware_type', 'name'])",
+        ".validate": "newData.hasChildren(['id', 'hardware_type', 'name', 'disabled'])",
         "id": {
           ".validate": "newData.isString()"
         },
@@ -313,6 +313,9 @@
         },
         "name": {
           ".validate": "newData.isString()"
+        },
+        "disabled": {
+          ".validate": "newData.isBoolean()"
         },
         "$other": {
           ".validate": "false"

--- a/firebase/functions/src/assign-server.ts
+++ b/firebase/functions/src/assign-server.ts
@@ -26,7 +26,7 @@ function getServerIdForHardwareType(hardwareType) {
        .once('value')
        .then(snapshot => snapshot.val())
        // pick a random server
-       .then(val => sample(toArray(val)))
+       .then(val => sample(toArray(val).filter(server => !server.disabled)))
        .then(server => server ? server.id : null)
        .then(serverId => {
          console.log(`Assigning randomly picked server ${serverId}`);


### PR DESCRIPTION
With this change a server can be set to
`disabled` in the database so that it
won't get any new executions assigned.

It will still get StopInvocations though
in order to keep responding to a users
wish to stop a process.

Fixes #388