### PR TITLE
feat(client): tune MessageStreamOptimizer params

### DIFF
--- a/client/src/app/editor/remote-code-execution/remote-lab-exec.service.ts
+++ b/client/src/app/editor/remote-code-execution/remote-lab-exec.service.ts
@@ -35,8 +35,8 @@ import '../../rx/takeWhileInclusive';
 @Injectable()
 export class RemoteLabExecService {
 
-  PARTITION_SIZE = 100;
-  FULL_FETCH_TRESHOLD = 500;
+  PARTITION_SIZE = 1000;
+  FULL_FETCH_TRESHOLD = 5000;
 
   messageStreamOptimizer: MessageStreamOptimizer;
 


### PR DESCRIPTION
The previous params where based on the asumption
that each message is always at least one line.
The truth is that sometimes one character is
using one message already. So with a head and
tail length of just 100 messages, that's often
far too less output.