### PR TITLE
feat(admin-cli): tune how personal configs work

### DIFF
--- a/admin-cli/index.ts
+++ b/admin-cli/index.ts
@@ -126,7 +126,7 @@ let argv = yargs(process.argv.slice(2))
       if ((argv._.includes('deploy') || argv._.includes('login') || argv._.includes('migrate') || argv._.includes('onboard')) && (!argv.cfg || !argv.cfg.target)) {
         throw new Error('Command needs `target`');
       }
-      
+
       if (argv.cfg && argv.cfg.target && (!argv.cfg.target.serverName || !argv.cfg.target.googleProjectId || !argv.cfg.target.zone)) {
         throw new Error('`target` option is incomplete');
       }

--- a/admin-cli/lib/load-template.ts
+++ b/admin-cli/lib/load-template.ts
@@ -1,19 +1,18 @@
 import * as fs from 'fs';
 import { templates } from '../config-templates/templates';
 
-export function getPersonalTemplatePath(templateName) {
-  return `${__dirname}/../config-templates/personal/template.${templateName}`;
-}
 
 export function tryLoadTemplate(templateName) {
 
-  const templatePath = getPersonalTemplatePath(templateName);
-  const isPersonalConfig = fs.existsSync(`${templatePath}.js`);
+  const personalConfigPath = `${__dirname}/../config-templates/personal/template.personal.js`;
+  const hasPersonalConfig = fs.existsSync(personalConfigPath);
   const isBuiltInConfig = templates[templateName];
+  const personalTemplates = hasPersonalConfig ? require(personalConfigPath).templates : {};
+  const isPersonalConfig = personalTemplates[templateName];
 
   if (!isPersonalConfig && !isBuiltInConfig) {
     throw new Error(`Can't find template ${templateName}`);
   }
 
-  return isPersonalConfig ? require(templatePath) : templates[templateName];
+  return isPersonalConfig ? personalTemplates[templateName] : templates[templateName];
 }


### PR DESCRIPTION
With this change the mechanism for personal
configs is slightly changed.

1. personal configs always have to be defined in
   one file:

   config-templates/personal/template.personal.ts

2. The structure matches exactly the checked
   in file config-templates/templates.ts

So the `template.personal.ts` may look like this:

```
export const templates = {
  personal: {
    target: {
      serverName: '-',
      zone: '-',
      googleProjectId: 'machinelabs-dev',
      fbDatabaseUrl: 'https://machinelabs-dev.firebaseio.com',
      fbPrivateKeyEnv: 'MACHINELABS_FB_PRIVATE_KEY',
      fbClientEmailEnv: 'MACHINELABS_FB_CLIENT_EMAIL'
    },
    env: 'fukuk'
  }
};
```