### PR TITLE
fix(server): start process as non interactive term

### DIFF
--- a/server/src/code-runner/docker-runner.ts
+++ b/server/src/code-runner/docker-runner.ts
@@ -38,7 +38,7 @@ EOL
                                 'run',
                                 '--cap-drop=ALL',
                                 '--security-opt=no-new-privileges',
-                                '-i',
+                                '-t',
                                 '--read-only',
                                 '--tmpfs',
                                 `/run:rw,size=${RUN_PARTITION_SIZE},mode=${RUN_PARTITION_MODE}`,


### PR DESCRIPTION
**WIP: DO NOT MERGE**

We used to start our processes in interactive mode.
That's wrong as we don't have a proper TTY as
input device. However, we can still set docker to
use term mode so that we can run things like top
etc.

- [ ] double check if the container still closes and removes when the execution is done