### PR TITLE
fix: fix broken execution list UI

### DIFF
--- a/client/src/app/lab-editor/execution-list/execution-list.component.scss
+++ b/client/src/app/lab-editor/execution-list/execution-list.component.scss
@@ -12,7 +12,7 @@ md-toolbar {
 .ml-execution-panel-header {
   font-weight: 400;
   md-icon {
-    vertical-align: -20%;
+    vertical-align: -25%;
     font-size: 22px;
     width: initial;
     height: initial;
@@ -23,11 +23,11 @@ md-toolbar {
     height: 27px;
     display: inline-block;
     margin-right: 0.2em;
-    vertical-align: -12%;
+    vertical-align: -45%;
 
     .mat-expanded & {
       height: 40px;
-      vertical-align: -20%;
+      vertical-align: -80%;
     }
   }
 


### PR DESCRIPTION
After we introduced Angular Material beta.10, progress spinners and icons in the
execution list accordion happened to be poorly align all of a sudden.

This commit corrects their visual alignment.