### PR TITLE
fix: make e2e tests work again

### DIFF
--- a/client/e2e/editor-view/editor-view.e2e-spec.ts
+++ b/client/e2e/editor-view/editor-view.e2e-spec.ts
@@ -22,9 +22,6 @@ describe('Editor-View Component', function() {
   it('should show the correct editor theme when switching editor views', () => {
     expect(editorView.editorMode).toEqual('python');
 
-    editorView.getTabByLabel('Console').click();
-    expect(editorView.editorMode).toEqual('sh');
-
     editorView.getTabByLabel('Editor').click();
     expect(editorView.editorMode).toEqual('python');
   });


### PR DESCRIPTION
Console is now an XtermComponent and doesn't come with editor modes,
as it's `sh` by default.