### PR TITLE
feat: make active tab configurable via URL query parameter

### DIFF
--- a/client/src/app/editor/editor.service.spec.ts
+++ b/client/src/app/editor/editor.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { EditorTestingModule } from './testing/editor-testing.module';
 import { Location } from '@angular/common';
+import { UrlSerializer } from '@angular/router';
 
 import { LAB_STUB } from '../../test-helper/stubs/lab.stubs';
 
@@ -10,6 +11,7 @@ describe('EditorService', () => {
 
   let editorService: EditorService;
   let location: Location;
+  let urlSerializer: UrlSerializer;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -18,6 +20,7 @@ describe('EditorService', () => {
 
     editorService = TestBed.get(EditorService);
     location = TestBed.get(Location);
+    urlSerializer = TestBed.get(UrlSerializer);
   });
 
   describe('.initLab()', () => {
@@ -37,7 +40,14 @@ describe('EditorService', () => {
 
     it('should update query param with first active file in lab directory', () => {
       editorService.initLab(expectedLab);
-      expect(location.path()).toEqual(`/?file=${expectedLab.directory[0].name}`);
+      expect(urlSerializer.parse(location.path()).queryParams.file)
+        .toEqual(expectedLab.directory[0].name);
+    });
+
+    it('should set tab query param to \'editor\' by default', () => {
+      editorService.initLab(expectedLab);
+      expect(urlSerializer.parse(location.path()).queryParams.tab)
+        .toEqual(TabIndex.Editor);
     });
 
     it('should activate query param file', () => {
@@ -61,6 +71,21 @@ describe('EditorService', () => {
       editorService.initLab(expectedLab);
       editorService.initDirectory(expectedLab.directory);
       expect(editorService.activeFile).toEqual(expectedLab.directory[0]);
+    });
+  });
+
+  describe('.selectTab()', () => {
+
+    it('should update tab query param accordingly', () => {
+      editorService.selectTab(TabIndex.Editor);
+
+      expect(urlSerializer.parse(location.path()).queryParams.tab)
+        .toEqual(TabIndex.Editor);
+
+      editorService.selectTab(TabIndex.Console);
+
+      expect(urlSerializer.parse(location.path()).queryParams.tab)
+        .toEqual(TabIndex.Console);
     });
   });
 

--- a/client/src/app/editor/editor.service.ts
+++ b/client/src/app/editor/editor.service.ts
@@ -20,9 +20,9 @@ import {
 } from '../models/execution';
 
 export enum TabIndex {
-  Editor,
-  Console,
-  Settings
+  Editor = 'editor',
+  Console = 'console',
+  Settings = 'settings'
 }
 
 import 'rxjs/add/observable/of';
@@ -72,7 +72,20 @@ export class EditorService {
   }
 
   initialize() {
-    this.selectedTab = TabIndex.Editor;
+    const tabParam = this.urlSerializer.parse(this.location.path()).queryParams.tab;
+
+    switch (tabParam) {
+      case TabIndex.Editor:
+        this.selectEditorTab();
+        break;
+      case TabIndex.Console:
+        this.selectConsoleTab();
+        break;
+      default:
+        this.selectEditorTab();
+        break;
+    }
+
     this.lab = null;
     this.latestLab = null;
     this.activeFile = null;
@@ -211,6 +224,9 @@ export class EditorService {
 
   selectTab(tabIndex: TabIndex) {
     this.selectedTab = tabIndex;
+    this.locationHelper.updateQueryParams(this.location.path(), {
+      tab: tabIndex
+    });
   }
 
   openFile(file: File) {

--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
@@ -67,7 +67,6 @@ export class EmbeddedEditorViewComponent implements OnInit {
   }
 
   listen() {
-    this.editorService.selectConsoleTab();
     this.console.clear();
     let wrapper = this.editorService.listenAndNotify(this.executionId);
 

--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -371,7 +371,6 @@ export class EditorViewComponent implements OnInit {
 
   initLab(lab: Lab, fetchExecutions = true) {
     this.editorService.initLab(lab);
-    this.selectTab(TabIndex.Editor);
     if (fetchExecutions) {
       this.initExecutionList();
     }
@@ -384,8 +383,7 @@ export class EditorViewComponent implements OnInit {
         .filter(executions => !!executions.length)
         .subscribe(_ => {
           this.openExecutionList()
-
-          if (this.activeExecutionId) {
+          if (this.activeExecutionId && !this.route.snapshot.queryParamMap.get('tab')) {
             this.editorService.selectConsoleTab();
           }
         });


### PR DESCRIPTION
This commit allows users to do things like:

```
/my-lab?tab=editor
```
or
```
/my-lab?tab=console
```

Also, the `tab` query parameter updates automatically when clicking on
tabs.

*ATTENTION*

This also removes the behaviour ob labs automatically selecting the console
tab when initializing an execution. This only happens if no `tab` queryParam
is given, enabling us to stay in the editor tab.