### PR TITLE
feat(client): reword rejection dialog

### DIFF
--- a/client/src/app/lab-editor/rejection-dialog/rejection-dialog.component.html
+++ b/client/src/app/lab-editor/rejection-dialog/rejection-dialog.component.html
@@ -2,8 +2,8 @@
   <ng-container *ngSwitchCase="ExecutionRejectionReason.NoAnonymous">
     <ml-dialog-header>Login to start executions</ml-dialog-header>
     <ml-dialog-content>
-      <p>You're just one click away from running that code!</p>
-      <p>No complicated setup, no credit cards! All you need to do is to <strong>login with your GitHub account</strong>.</p>
+      <p>Almost there! To prevent abuse of our platform, only logged in users can launch executions.</p>
+      <p>Just <strong>login with your GitHub account</strong> and do Machine Learning without the hassle.</p>
     </ml-dialog-content>
     <ml-dialog-cta-bar>
       <button md-button [mdDialogClose]="true" (click)="loginWithGithub()">Login with GitHub</button>


### PR DESCRIPTION
This change tunes the wording of the rejection
dialog for anonymous users a bit.

Users are more likely to accept a rejection
if they know the reason for it (studies prove that).

So with this rewording, we are telling the user
that we require the login to prevent abuse
of the platform.