### PR TITLE
fix: only trigger cloud function for freshly written files

### DIFF
--- a/firebase/functions/src/uploads/add-outputs.ts
+++ b/firebase/functions/src/uploads/add-outputs.ts
@@ -6,7 +6,7 @@ import { UploadType } from './upload-type';
 
 export const bucketChange = functions.storage.object().onChange(event => {
 
-  if (!event.data || !event.data.metadata || event.data.metadata['type'] !== UploadType.ExecutionOutput) {
+  if (!event.data || event.data.metageneration > 1 || !event.data.metadata || event.data.metadata['type'] !== UploadType.ExecutionOutput) {
     return Promise.resolve(true);
   }
 


### PR DESCRIPTION
Without this check, the cloud function will also be
triggered when files or its meta data changes.
This will for instance also be triggered if we
request to generate a download URL for a file