### PR TITLE
fix: preserve query parameter when switching tabs

### DIFF
--- a/client/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.html
@@ -19,7 +19,7 @@
           [active]="editorService.consoleTabActive()">Console</a>
 
         <a routerLink="."
-           queryParamsHanding="merge"
+           queryParamsHandling="merge"
            mdTabLink
            (click)="selectTab(TabIndex.Outputs)"
            [active]="editorService.outputsTabActive()">Outputs</a>


### PR DESCRIPTION
Fixes #494