### PR TITLE
wip: fixes shit

### DIFF
--- a/client/src/app/editor/editor.service.ts
+++ b/client/src/app/editor/editor.service.ts
@@ -1,6 +1,6 @@
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
-import { Injectable } from '@angular/core';
+import { Injectable, EventEmitter } from '@angular/core';
 import { UrlSerializer } from '@angular/router';
 import { Location } from '@angular/common';
 import { LocationHelper } from '../util/location-helper';
@@ -43,6 +43,8 @@ export interface ListenAndNotifyOptions {
 
 @Injectable()
 export class EditorService {
+
+  selectedTabChange = new EventEmitter<TabIndex>();
 
   selectedTab: TabIndex;
 
@@ -228,6 +230,7 @@ export class EditorService {
     this.locationHelper.updateQueryParams(this.location.path(), {
       tab: tabIndex
     });
+    this.selectedTabChange.emit(tabIndex);
   }
 
   openFile(file: File) {

--- a/client/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.html
@@ -49,7 +49,7 @@
         <ml-editor-layout-panel [class.hidden]="!editorService.consoleTabActive()">
           <ml-xterm
             #outputPanel
-            [messages]="output"
+            [messages]="consumedOutput"
             [scrollback]="5000"
           ></ml-xterm>
           <div class="ml-scroll-checkbox">


### PR DESCRIPTION
### DO NOT MERGE

This is a potential fix for #493. It works by not passing the `Observable<string>` to the `XTermComponent` until the output tab got active.

There are several problems with this:

1. Introduces a new bug where the editor does not resize properly if you land on the output tab and then change to the editor tab

2. I'm not sure if I like it