### PR TITLE
fix: jumping between files when saving

### DIFF
--- a/client/src/app/editor/editor.service.ts
+++ b/client/src/app/editor/editor.service.ts
@@ -71,8 +71,7 @@ export class EditorService {
     private editorSnackbar: EditorSnackbarService,
     private labStorageService: LabStorageService,
     private rleService: RemoteLabExecService,
-    private labExecutionService: LabExecutionService,
-    private route: ActivatedRoute
+    private labExecutionService: LabExecutionService
   ) {
     this.initialize();
   }
@@ -201,10 +200,12 @@ export class EditorService {
         if (this.activeExecutionId) {
           urlSegments.push(this.activeExecutionId);
         }
+
         this.locationHelper.updateUrl(urlSegments, {
-          queryParamsHandling: 'preserve',
-          queryParams: this.route.snapshot.queryParams
+          queryParamsHandling: 'merge',
+          queryParams: this.locationHelper.getQueryParams(this.location.path())
         });
+
         this.editorSnackbar.notify(msg);
       })
       .map(_ => lab);

--- a/client/src/app/util/location-helper.ts
+++ b/client/src/app/util/location-helper.ts
@@ -20,6 +20,11 @@ export class LocationHelper {
     ));
   }
 
+  getQueryParams(path: string) {
+    const currentUrlTree = this.router.parseUrl(path);
+    return currentUrlTree.queryParams;
+  }
+
   updateQueryParams(path: string, params) {
     const currentUrlTree = this.router.parseUrl(path);
     currentUrlTree.queryParams = Object.assign({}, currentUrlTree.queryParams, params);


### PR DESCRIPTION
Fixes #523. It seems that the `merge` strategy performs better in this case compared to `preserve`. However, this alone doesn't do the trick and it was necessary to construct an url tree from the current `path` and pass along the query params in order to update the URL and the internal state of the router.