### PR TITLE
fix: make `tab` query param work in emebedded editor view

### DIFF
--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
@@ -59,10 +59,7 @@ export class EmbeddedEditorViewComponent implements OnInit {
     this.editorService.initialize();
     this.executionId = this.route.snapshot.paramMap.get('executionId');
     this.route.data.map(data => data['lab'])
-              .subscribe(lab => {
-                this.editorService.initLab(lab);
-                this.editorService.selectEditorTab();
-              });
+              .subscribe(lab => this.editorService.initLab(lab));
 
     if (!this.executionId) {
       setTimeout(_ => this.showDialog());


### PR DESCRIPTION
So far we've always activated the editor tab and ignored the `tab` query
param when initializing the embedded editor view. This commit removes the
explicit activation so it can rely on the `tab` param. It still falls back
to the editor tab.