### PR TITLE
fix(file-preview) fix spinner

### DIFF
--- a/client/src/app/editor/file-preview/file-preview-dialog/file-preview-dialog.component.html
+++ b/client/src/app/editor/file-preview/file-preview-dialog/file-preview-dialog.component.html
@@ -19,7 +19,10 @@
   (@slideContent.start)="onAnimationStart($event)"
   (@slideContent.done)="onAnimationDone($event)">
 
-  <mat-spinner mode="indeterminate" *ngIf="loading && !error"></mat-spinner>
+  <div class="ml-spinner-wrapper" *ngIf="loading && !error">
+    <mat-spinner mode="indeterminate" ></mat-spinner>
+  </div>
+
   <img [@fade]="loading ? 'fadeOut' : 'fadeIn'" #image [src]="outputFile.download_url"
     (load)="onLoad($event)" (error)="onError($event)" alt="Output file">
 

--- a/client/src/app/editor/file-preview/file-preview-dialog/file-preview-dialog.component.scss
+++ b/client/src/app/editor/file-preview/file-preview-dialog/file-preview-dialog.component.scss
@@ -40,10 +40,10 @@ ml-dialog-error {
   }
 }
 
-mat-spinner {
+.ml-spinner-wrapper {
   position: absolute;
-  top: 50;
-  left: 50;
+  top: 50%;
+  left: 50%;
   transform: translate(-50%, -50%);
   z-index: -1;
 }


### PR DESCRIPTION
I had to introduce a wrapper element for the spinner which is positioned absolutely. With the latest Material update they now apply a CSS Keyframe animation to the spinner that overrides any transforms. As a result it can not be correctly positioned in the middle of its container.