### PR TITLE
refactor(client): introduce snapshotToValue helper

### DIFF
--- a/client/src/app/editor/remote-code-execution/message-stream-optimizer.ts
+++ b/client/src/app/editor/remote-code-execution/message-stream-optimizer.ts
@@ -2,6 +2,8 @@ import { DbRefBuilder } from '../../firebase/db-ref-builder';
 import { Observable } from 'rxjs/Observable';
 import { ExecutionMessage, MessageKind } from '../../models/execution';
 import { createSkipText } from '../util/skip-helper'
+import 'rxjs/add/operator/let';
+import { snapshotToValue } from '../../rx/snapshotToValue';
 
 export class MessageStreamOptimizer {
   constructor(private db: DbRefBuilder, private partitionSize, private fullFetchTreshold) {
@@ -30,7 +32,7 @@ export class MessageStreamOptimizer {
                   .limitToLast(1)
                   .childAdded()
                   .take(1)
-                  .map(snapshot => snapshot.val());
+                  .let(snapshotToValue);
   }
 
   getHeadMessages(executionId, partitionSize) {
@@ -40,7 +42,7 @@ export class MessageStreamOptimizer {
                                .limitToFirst(partitionSize)
                                .childAdded()
                                .take(partitionSize)
-                               .map(snapshot => snapshot.val());
+                               .let(snapshotToValue);
   }
 
   getTailMessages(executionId, startAt, partitionSize) {
@@ -50,7 +52,7 @@ export class MessageStreamOptimizer {
                   .limitToFirst(partitionSize)
                   .childAdded()
                   .take(partitionSize)
-                  .map(snapshot => snapshot.val());
+                  .let(snapshotToValue);
   }
 
   getLiveMessages(executionId, startAt) {
@@ -58,13 +60,13 @@ export class MessageStreamOptimizer {
                    .orderByChild('index')
                    .startAt(startAt)
                    .childAdded()
-                   .map(snapshot => snapshot.val());
+                   .let(snapshotToValue);
   }
 
   getAllMessages(executionId) {
     return this.db.executionMessageRef(executionId)
                .childAdded()
-               .map(snapshot => snapshot.val());
+               .let(snapshotToValue);
   }
 
 }

--- a/client/src/app/editor/remote-code-execution/remote-lab-exec.service.ts
+++ b/client/src/app/editor/remote-code-execution/remote-lab-exec.service.ts
@@ -32,6 +32,7 @@ import 'rxjs/add/operator/concat';
 import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/takeUntil';
 import '../../rx/takeWhileInclusive';
+import { snapshotToValue } from '../../rx/snapshotToValue';
 
 @Injectable()
 export class RemoteLabExecService {
@@ -64,7 +65,7 @@ export class RemoteLabExecService {
         }
       }))
       .switchMap(_ =>  this.db.executionMessageRef(id).limitToFirst(1).childAdded().take(1))
-      .map(snapshot => snapshot.val())
+      .let(snapshotToValue)
       .switchMap(message => {
         // If the execution was rejected, there's no point to try to fetch it
         // hence we directly return the ExecutionInvocationInfo which ends the whole stream
@@ -84,7 +85,7 @@ export class RemoteLabExecService {
           // value, hence we filter it out.
           return this.db.executionRef(id)
                  .value()
-                 .map(s => s.val())
+                 .let(snapshotToValue)
                  .takeWhileInclusive(e => e === null)
                  .filter(e => e !== null)
                  .map(_ => ({ persistent: true, executionId: id, rejection: null}));
@@ -115,7 +116,7 @@ export class RemoteLabExecService {
 
     let execution$ = this.db.executionRef(executionId)
                             .value()
-                            .map(snapshot => snapshot.val())
+                            .let(snapshotToValue)
                             .map(execution => {
                               if (typeof execution.lab.directory === 'string') {
                                 execution.lab.directory = JSON.parse(execution.lab.directory);
@@ -214,6 +215,6 @@ export class RemoteLabExecService {
                   .limitToFirst(1)
                   .childAdded()
                   .take(1)
-                  .map(snapshot => snapshot.val());
+                  .let(snapshotToValue);
   }
 }

--- a/client/src/app/lab-execution.service.ts
+++ b/client/src/app/lab-execution.service.ts
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/scan';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
+import { snapshotToValue } from 'app/rx/snapshotToValue';
 
 @Injectable()
 export class LabExecutionService {
@@ -22,7 +23,7 @@ export class LabExecutionService {
     return this.authService
               .requireAuthOnce()
               .switchMap(_ => this.db.executionRef(id).value())
-              .map((snapshot: any) => snapshot.val());
+              .let(snapshotToValue);
   }
 
   observeExecutionsForLab(lab: Lab): Observable<Array<{id: string, execution: Observable<Execution>}>> {
@@ -49,7 +50,7 @@ export class LabExecutionService {
     return this.authService
       .requireAuthOnce()
       .switchMap(_ => this.db.labExecutionsRef(id).limitToLast(1).onceValue())
-      .map((snapshot: any) => snapshot.val())
+      .let(snapshotToValue)
       .map(value => value ? Object.keys(value)[0] : null);
   }
 
@@ -57,14 +58,14 @@ export class LabExecutionService {
     return this.authService
       .requireAuthOnce()
       .switchMap(_ => this.db.executionRef(id).onceValue())
-      .map((snapshot: any) => snapshot.val());
+      .let(snapshotToValue);
   }
 
   getLatestVisibleExecutionIdForLab(id: string) {
     return this.authService
       .requireAuthOnce()
       .switchMap(_ => this.db.labVisibleExecutionsRef(id).limitToLast(1).onceValue())
-      .map((snapshot: any) => snapshot.val())
+      .let(snapshotToValue)
       .map(value => value ? Object.keys(value)[0] : null);
   }
 
@@ -79,7 +80,7 @@ export class LabExecutionService {
     return this.authService
       .requireAuthOnce()
       .switchMap(_ => this.db.labVisibleExecutionsRef(id).onceValue())
-      .map((snapshot: any) => snapshot.val())
+      .let(snapshotToValue)
       .map(executionIds => Object.keys(executionIds || {}))
       .map(executionIds => executionIds.map(executionId => this.getExecution(executionId)))
       .switchMap(executionRefs => executionRefs.length ? Observable.forkJoin(executionRefs) : Observable.of([]))

--- a/client/src/app/lab-storage.service.ts
+++ b/client/src/app/lab-storage.service.ts
@@ -13,6 +13,7 @@ import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
+import { snapshotToValue } from './rx/snapshotToValue';
 
 @Injectable()
 export class LabStorageService {
@@ -51,7 +52,7 @@ export class LabStorageService {
     return this.authService
               .requireAuthOnce()
               .switchMap(_ => this.db.labRef(id).onceValue())
-              .map((snapshot: any) => snapshot.val())
+              .let(snapshotToValue)
               .map(value => {
                 // existing lab directories might not be converted yet
                 // this can be removed once we know for sure that all lab directories
@@ -96,7 +97,7 @@ export class LabStorageService {
   getLabsFromUser(userId: string): Observable<Array<Lab>> {
     return this.db.userVisibleLabsRef(userId)
               .onceValue()
-              .map((snapshot: any) => snapshot.val())
+              .let(snapshotToValue)
               .map(labIds => Object.keys(labIds || {}))
               .map(labIds => labIds.map(labId => this.getLab(labId)))
               .switchMap(labRefs => labRefs.length ? Observable.forkJoin(labRefs) : Observable.of([]))

--- a/client/src/app/output-files.service.ts
+++ b/client/src/app/output-files.service.ts
@@ -11,8 +11,8 @@ import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/mergeMap';
+import { snapshotToValue } from './rx/snapshotToValue';
 
-const fromSnapshot = snapshot => snapshot.val();
 
 @Injectable()
 export class OutputFilesService {
@@ -25,7 +25,7 @@ export class OutputFilesService {
   observeOutputFilesFromExecution(executionId: string): Observable<OutputFile> {
     return this.authService
                .requireAuthOnce()
-               .switchMap(_ => this.db.executionOutputFilesRef(executionId).childAdded().map(fromSnapshot))
+               .switchMap(_ => this.db.executionOutputFilesRef(executionId).childAdded().let(snapshotToValue))
                .flatMap(file => this.getDownloadUrlForPath(file.path).map(download_url => ({...file, download_url})));
   }
 

--- a/client/src/app/rx/snapshotToValue.ts
+++ b/client/src/app/rx/snapshotToValue.ts
@@ -1,0 +1,5 @@
+import { Observable } from 'rxjs/Observable';
+import * as firebase from 'firebase';
+
+export const snapshotToValue = (source: Observable<firebase.database.DataSnapshot>) =>
+  source.map(snapshot => snapshot.val());

--- a/client/src/app/user/user.service.ts
+++ b/client/src/app/user/user.service.ts
@@ -9,6 +9,7 @@ import { Lang } from '../util/lang';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
+import { snapshotToValue } from '../rx/snapshotToValue';
 
 export const PLACEHOLDER_USERNAME = 'Unnamed User';
 
@@ -22,7 +23,7 @@ export class UserService {
                .requireAuthOnce()
                .switchMap((user: LoginUser) => this.db.userRef(user.uid)
                                                       .onceValue()
-                                                      .map(snapshot => snapshot.val())
+                                                      .let(snapshotToValue)
                                                       .map(existingUser => ({existingUser, user})))
                .switchMap(data => !data.existingUser || this.isDifferent(data.user, data.existingUser)
                                     ? this.saveUser(this.mapLoginUserToUser(data.user))
@@ -73,7 +74,7 @@ export class UserService {
   getUser(id: string): Observable<User> {
     return this.authService.requireAuthOnce()
                            .switchMap(_ => this.db.userRef(id).onceValue())
-                           .map(snapshot => snapshot.val());
+                           .let(snapshotToValue);
 
   }
 


### PR DESCRIPTION
Created a helper function to get rid of all our repetitive snapshot mapping code. I realize that @PascalPrecht is currently working on migrating all our Rx code to lettable operators so this may have to wait until @PascalPrecht 's PR lands.

I'll let @PascalPrecht decide about this.