### PR TITLE
fix: fix prod CI builds by nailing yarn version to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - export CHROME_BIN=chromium-browser
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start
-        - npm install -g yarn typescript
+        - npm install -g yarn@1.0.0 typescript
       before_script:
         - npm install -g @angular/cli
     - stage: "client"
@@ -57,7 +57,7 @@ matrix:
         - export CHROME_BIN=chromium-browser
         - export DISPLAY=:99.0
         - sh -e /etc/init.d/xvfb start
-        - npm install -g yarn typescript
+        - npm install -g yarn@1.0.0 typescript
       before_script:
         - npm install -g @angular/cli
       script: npm run test:e2e:production


### PR DESCRIPTION
For some reason, client production builds fail with yarn version 1.2.x,
which is the version that at the time of creating this commit was gonna
be used.