### PR TITLE
fix(server): use quotes for input names and URLs

### DIFF
--- a/server/src/code-runner/downloader/docker-file-downloader.ts
+++ b/server/src/code-runner/downloader/docker-file-downloader.ts
@@ -36,7 +36,7 @@ export class DockerFileDownloader {
       containerId,
       '/bin/bash',
       '-c',
-      `mkdir -p /run/inputs && curl --progress-bar -o /run/inputs/${input.name} -L ${input.url}`
+      `mkdir -p /run/inputs && curl --progress-bar -o "/run/inputs/${input.name}" -L "${input.url}"`
     ])
     // When the progress bar reaches 100 % it renders a new line which
     // then destroys all the other progress bars below, hence we filter it out.


### PR DESCRIPTION
This fixes a bug where some URLs would not work
because they needed to be quoted.

E.g. This URL did not work previously but works
after this fix:

https://data.austintexas.gov/api/geospatial/23x8-agw7?method=export&format=Original

Fixes #571