### PR TITLE
fix(EmbeddedEditorView): use lettable operators

### DIFF
--- a/client/e2e/embedded-editor-view/embedded-editor-view.e2e-spec.ts
+++ b/client/e2e/embedded-editor-view/embedded-editor-view.e2e-spec.ts
@@ -1,0 +1,21 @@
+import { browser, protractor, element, by } from 'protractor';
+
+import { waitForContentReady } from './../utils';
+import { EmbeddedEditorViewPageObject } from './embedded-editor-view.page-object';
+
+describe('Editor-View Component', () => {
+
+  const embeddedEditorView = new EmbeddedEditorViewPageObject();
+
+  beforeEach(() => {
+    browser.get('/embedded');
+    waitForContentReady();
+  });
+
+  it('should active tab by query parameter', () => {
+    browser.get('/embedded?tab=console');
+    waitForContentReady();
+    expect(embeddedEditorView.activeTabLabel).toEqual('Console');
+  });
+});
+

--- a/client/e2e/embedded-editor-view/embedded-editor-view.page-object.ts
+++ b/client/e2e/embedded-editor-view/embedded-editor-view.page-object.ts
@@ -1,0 +1,16 @@
+import {
+  protractor,
+  browser,
+  element,
+  by,
+  ElementFinder,
+  ElementArrayFinder,
+  promise
+} from 'protractor';
+
+export class EmbeddedEditorViewPageObject {
+
+  get activeTabLabel(): promise.Promise<string> {
+    return element(by.css('.mat-tab-link[ng-reflect-active="true"]')).getText();
+  }
+}

--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.scss
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.scss
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  background: #fafafa;
+}
+
 [matTabLink] {
   height: 40px;
   min-width: 100px;

--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
@@ -4,7 +4,7 @@ import { MatDialog, MatDialogRef } from '@angular/material';
 import { File } from '@machinelabs/models';
 
 import { Observable } from 'rxjs/Observable';
-import { take } from 'rxjs/operators';
+import { take, map } from 'rxjs/operators';
 
 import { LabExecutionService } from '../../lab-execution.service';
 import { EditorService, TabIndex } from '../../editor/editor.service';
@@ -58,7 +58,8 @@ export class EmbeddedEditorViewComponent implements OnInit {
     // one would get when all the state would live in the component.
     this.editorService.initialize();
     this.executionId = this.route.snapshot.paramMap.get('executionId');
-    this.route.data.map(data => data['lab'])
+    this.route.data
+      .pipe(map(data => data['lab']))
               .subscribe(lab => this.editorService.initLab(lab));
 
     if (!this.executionId) {


### PR DESCRIPTION
Forgot one more place to use lettable operators. This broke our embedded editor view as discussed in #608

Fixes #608