### PR TITLE
fix: ensure user_executions idx is always updated

### DIFF
--- a/firebase/functions/src/post-execution-write.ts
+++ b/firebase/functions/src/post-execution-write.ts
@@ -4,7 +4,7 @@ import { TriggerAnnotated, Event} from 'firebase-functions';
 import { DeltaSnapshot } from 'firebase-functions/lib/providers/database';
 
 
-import { appendEntryToMonthIndex } from './user-execution-index-tools';
+import { appendEntryToMonthIndex, updateUserExecutions } from './user-execution-index-tools';
 import { pathify } from './util/pathify';
 
 export const postExecutionWrite = functions.database.ref('/executions/{id}/common')
@@ -32,23 +32,7 @@ function updateLabExecution(event, data, delta) {
   delta[`/idx/lab_executions/${data.lab.id}/${data.id}`] = true;
 }
 
-function updateUserExecutions(event, data, delta) {
-  if (data.started_at && data.finished_at) {
-    let userIdx = {};
-    let idx = {
-      idx: {
-        user_executions: {
-          [data.user_id]: userIdx
-        }
-      }
-    };
 
-    appendEntryToMonthIndex(userIdx, data.started_at, data.finished_at, data.id);
-    Object.assign(delta, pathify(idx));
-  }
-
-  delta[`/idx/user_executions/${data.user_id}/live/${data.id}`] = data.finished_at ? null : true;
-}
 
 function updateRecentLabs(event, data, delta) {
   delta[`/idx/recent_labs/${data.lab.id}`] = {

--- a/firebase/functions/src/user-execution-index-tools.spec.ts
+++ b/firebase/functions/src/user-execution-index-tools.spec.ts
@@ -1,5 +1,5 @@
 import 'jest';
-import { appendEntryToMonthIndex } from './user-execution-index-tools';
+import { appendEntryToMonthIndex, updateUserExecutions } from './user-execution-index-tools';
 
 describe('appendEntryToMonthIndex', () => {
   it('should create index tree of months', () => {
@@ -30,5 +30,96 @@ describe('appendEntryToMonthIndex', () => {
     };
 
     expect(index).toEqual(expected);
+  });
+});
+
+
+describe('updateUserExecutions', () => {
+  it('should add live entry', () => {
+
+    let delta = {};
+
+    let execution = {
+      id: '1',
+      user_id: 'foo',
+      started_at: 1000
+    };
+
+    let expected = {
+      '/idx/user_executions/foo/live/1': true
+    };
+
+    updateUserExecutions(null, execution, delta);
+
+    expect(delta).toEqual(expected);
+  });
+
+  it('should kill live entry and add 1970-Jan entry', () => {
+
+    let delta = {};
+
+    let execution = {
+      id: '1',
+      user_id: 'foo',
+      started_at: 1000,
+      finished_at: 1100
+    };
+
+    let expected = {
+      '/idx/user_executions/foo/1970/Jan/1': true,
+      '/idx/user_executions/foo/live/1': null,
+    };
+
+    updateUserExecutions(null, execution, delta);
+
+    expect(delta).toEqual(expected);
+  });
+
+  it('should kill live entry and add 2001-Sep entry (stopped_at)', () => {
+
+    let delta = {};
+
+    let execution = {
+      id: '1',
+      user_id: 'foo',
+      started_at:  1000000000000,
+      stopped_at: 1001000000000,
+      finished_at: 1002000000000
+    };
+
+    // we don't want to see Oct here because it should use the
+    // `stopped_at` rather than `finished_at` value
+    let expected = {
+      '/idx/user_executions/foo/2001/Sep/1': true,
+      '/idx/user_executions/foo/live/1': null,
+    };
+
+    updateUserExecutions(null, execution, delta);
+
+    expect(delta).toEqual(expected);
+  });
+
+  it('should kill live entry and add 2001-Sep entry (failed_at)', () => {
+
+    let delta = {};
+
+    let execution = {
+      id: '1',
+      user_id: 'foo',
+      started_at:  1000000000000,
+      failed_at: 1001000000000,
+      finished_at: 1002000000000
+    };
+
+    // we don't want to see Oct here because it should use the
+    // `failed_at` rather than `finished_at` value
+    let expected = {
+      '/idx/user_executions/foo/2001/Sep/1': true,
+      '/idx/user_executions/foo/live/1': null,
+    };
+
+    updateUserExecutions(null, execution, delta);
+
+    expect(delta).toEqual(expected);
   });
 });

--- a/firebase/functions/src/user-execution-index-tools.ts
+++ b/firebase/functions/src/user-execution-index-tools.ts
@@ -1,6 +1,7 @@
 
 import * as moment from 'moment';
 import * as merge from 'lodash.merge';
+import { pathify } from './util/pathify';
 
 function resetToBeginOfMonth(date) {
   return date.date(1)
@@ -28,11 +29,34 @@ export function appendEntryToMonthIndex(index, startDate, endDate, executionId) 
   while (currentDate.isSameOrBefore(endDate)) {
     let year = currentDate.year();
     let month = currentDate.format('MMM');
-
     merge(index, { [year]: { [month]: { [executionId]: true } } });
 
     currentDate.add(1, 'month');
   }
 
   return index;
+}
+
+export function updateUserExecutions(event, data, delta) {
+
+  let finalized = data.finished_at || data.stopped_at || data.failed_at;
+
+  if (data.started_at && finalized) {
+    let userIdx = {};
+    let idx = {
+      idx: {
+        user_executions: {
+          [data.user_id]: userIdx
+        }
+      }
+    };
+
+    let finalizedAt = data.stopped_at ? data.stopped_at :
+                      data.failed_at ? data.failed_at : data.finished_at;
+
+    appendEntryToMonthIndex(userIdx, data.started_at, finalizedAt, data.id);
+    Object.assign(delta, pathify(idx));
+  }
+
+  delta[`/idx/user_executions/${data.user_id}/live/${data.id}`] = finalized ? null : true;
 }


### PR DESCRIPTION
Previously, the index wasn't updated in case
finished_at would be missing but stopped_at
or failed_at is set.

Fixes #616