### PR TITLE
fix(EditorService): ensure activeFilePath is set when opening file

### DIFF
--- a/client/src/app/editor/editor.service.ts
+++ b/client/src/app/editor/editor.service.ts
@@ -266,7 +266,6 @@ export class EditorService {
   }
 
   openFile(file: File, path?: string) {
-
     if (this.activeFilePath) {
       // it's important to retrieve the previousActiveFile via its path because when we
       // run an execution, we are overwriting `lab.directory` with a new directory
@@ -278,7 +277,7 @@ export class EditorService {
     }
 
     this.activeFile = file;
-    this.activeFilePath = path;
+    this.activeFilePath = path || file.name;
     this.fileTreeService.selectFile(this.activeFile);
 
     this.locationHelper.updateQueryParams(this.location.path(), {


### PR DESCRIPTION
As part of https://github.com/machinelabs/machinelabs/commit/5db9b0537324a02c50d3f944b923b45d7c3e7359 we've introduced a regression that sets
an invalid state in our `EditorService`, where the `activeFilePath`
is not set on lab initalization, when no `file` query parameter is
given.

This fix ensures that `activeFilePath` always gets a value when a
file is opened - either the full path of the file to be opened, or,
if a lab is opened without a file path, just the file name itself.
This usually means the default entry file (right now `main.py`) is set.

For more information see:

https://github.com/machinelabs/machinelabs/issues/570#issuecomment-346023151

Fixes #570