### PR TITLE
fix(HasValidExecutionGuard): ensure hidden executions can't be visited

### DIFF
--- a/client/src/app/lab-editor/has-valid-execution.guard.ts
+++ b/client/src/app/lab-editor/has-valid-execution.guard.ts
@@ -57,7 +57,7 @@ export class HasValidExecutionGuard implements CanActivate {
 
     return !executionId ?
       checkForLatestExecution$ :
-      this.labExecutionService.executionExists(executionId)
+      this.labExecutionService.executionExistsAndVisible(executionId)
         .pipe(switchMap(exists => exists ? of(true) : checkForLatestExecution$));
   }
 }

--- a/client/src/app/lab-execution.service.ts
+++ b/client/src/app/lab-execution.service.ts
@@ -92,6 +92,14 @@ export class LabExecutionService {
     );
   }
 
+  executionExistsAndVisible(id: string) {
+    return this.authService.requireAuth().pipe(
+      switchMap(_ => this.db.executionRef(id).onceValue()),
+      snapshotToValue,
+      map(execution => !execution.hidden)
+    );
+  }
+
   getExecutionsFromLab(id: string) {
     return this.authService.requireAuthOnce().pipe(
       switchMap(_ => this.db.labVisibleExecutionsRef(id).onceValue()),


### PR DESCRIPTION
Fixes #630