### PR TITLE
fix(EditorService): ensure we have no duplicates in execution list up…

### DIFF
--- a/client/src/app/lab-execution.service.ts
+++ b/client/src/app/lab-execution.service.ts
@@ -45,7 +45,19 @@ export class LabExecutionService {
       scan((
         acc: Array<{id: string, execution: Observable<Execution> }>,
         val: {id: string, execution: Observable<Execution>}
-      ) => [val, ...acc], []),
+      ) => {
+        // Some updates on executions cause changes in our database indices that
+        // can make the same execution being pushed and therefore show up twice
+        // in the execution list. That's why remove the latest added execution in the
+        // list (always the first one) if it already exists.
+        //
+        // More information:
+        // https://github.com/machinelabs/machinelabs/issues/632#issuecomment-347498709
+        if(!acc.find(execution => execution.id === val.id)) {
+          return [val, ...acc]
+        }
+        return acc;
+      }, []),
       map(val => [...val])
     );
   }


### PR DESCRIPTION
…dates

Some changes on execution objects (like setting `hidden` state)
cause changes in our database indices that trigger `child_added` events
and make our execution list re-add the same execution object multiple
times.

This caused a bug when executions have been removed through the UI and
then "undo-ed", that the same execution showed up 2 - n times.

This commit ensures that, when an execution is being pushed in the execution
list, we first check if that same execution already exists in the list. If
that's the case, we remove the first item again.

For more information:

https://github.com/machinelabs/machinelabs/issues/632#issuecomment-347498709

Fixes #632