### PR TITLE
fix(server): tune recycle parameter

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,10 +44,10 @@ const usageStatisticService = new UsageStatisticService(new CostCalculator(), <a
 const recycleService = new RecycleService({
   messageRepository: new MessageRepository(),
   getMessageTimeout: 5000,
-  triggerIndex: 7000,
-  triggerIndexStep: 100,
-  tailLength: 6000,
-  deleteCount: 5000
+  triggerIndex: 5000,
+  triggerIndexStep: 1000,
+  tailLength: 4000,
+  deleteCount: 3000
 });
 
 const uploader = new DockerFileUploader(50, 5);


### PR DESCRIPTION
The idea behind this change goes as follows:

- let the recycling happen a bit earlier
  (at 5k messages instead of 7k)

- reduce the number of messages that
  need to be fetched and moved around
  per run. (4k instead of 6k)

- if a recycling fails, give it more
  time to recover by pushing the
  next recycling further into the future
  (1000 messages further instead of just 100)

In theory, these changes should lead to
more frequent recycling with a lower footprint.