### PR TITLE
fix: set contentType on uploads to empty string

### DIFF
--- a/firebase/functions/src/uploads/add-outputs.ts
+++ b/firebase/functions/src/uploads/add-outputs.ts
@@ -17,7 +17,7 @@ export const bucketChange = functions.storage.object().onChange(event => {
   let output = {
     id, execution_id, user_id, name,
     path: event.data.name,
-    content_type: event.data.contentType,
+    content_type: '',
     created_at: Date.now(),
     size_bytes: event.data.size
   };


### PR DESCRIPTION
The contentType used to exist on the bucket event
object but doesn't seem to exist anymore. This
never really worked as the contentType always
used to be an empty string but now that it is
undefined it's crashing our cloud function.

This change sets it to empty string until we
fix that properly. The reason we prefer an
empty string over removing it entirely, is, that
now all depending code can safely assume there
is at least a field content_type of type string.