### PR TITLE
fix(EditorViewComponent): toggle file tree sidebar when activated for…

### DIFF
--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -156,7 +156,9 @@ export class EditorViewComponent implements OnInit, AfterViewInit {
 
   selectTab(tabIndex: TabIndex) {
     this.editorService.selectTab(tabIndex);
-    if (this.editorService.consoleTabActive() && this.outputPanel) {
+    if (this.editorService.editorTabActive() && !this.fileTreeSidebarOpened) {
+      this.openFileTreeSidebar();
+    } else if (this.editorService.consoleTabActive() && this.outputPanel) {
       setTimeout(_ => this.outputPanel.resize(), 0);
     }
   }


### PR DESCRIPTION
… the first time

This was a regression introduced in #657 where we accidently removed the code that
ensures the file tree sidebar is toggled when the editor view is activated for the
first time.