### PR TITLE
fix(EditorView): ensure MonacoEditor's models are disposed before ini…

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,7 @@
     "js-yaml": "^3.8.4",
     "ng2-slim-loading-bar": "^4.0.0",
     "ngx-clipboard": "^9.0.0",
-    "ngx-monaco": "^0.5.2",
+    "ngx-monaco": "0.6.0",
     "rxjs": "5.5.2",
     "shortid": "2.2.6",
     "xterm": "^2.9.2",

--- a/client/src/app/editor/editor.service.ts
+++ b/client/src/app/editor/editor.service.ts
@@ -6,6 +6,8 @@ import { Injectable, EventEmitter } from '@angular/core';
 import { UrlSerializer, ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 
+import { MonacoEditorService } from 'ngx-monaco';
+
 import {
   LabDirectory,
   File,
@@ -82,6 +84,7 @@ export class EditorService {
     private rleService: RemoteLabExecService,
     private labExecutionService: LabExecutionService,
     private route: ActivatedRoute,
+    private monacoEditorService: MonacoEditorService,
     private fileTreeService: FileTreeService
   ) {
     this.initialize();
@@ -105,6 +108,7 @@ export class EditorService {
 
   initLab(lab: Lab, collapseDirectories = true) {
     this.lab = lab;
+    this.monacoEditorService.disposeModels();
 
     if (collapseDirectories) {
       this.fileTreeService.collapseAll(this.lab.directory);

--- a/client/src/app/editor/testing/editor-testing.module.ts
+++ b/client/src/app/editor/testing/editor-testing.module.ts
@@ -5,6 +5,8 @@ import { MatDialogModule } from '@angular/material';
 import { MachineLabsMaterialModule } from '../../ml-material.module';
 import { EditorModule } from '../editor.module';
 
+import { MonacoEditorService } from 'ngx-monaco';
+
 import { EditorService } from '../editor.service';
 import { EditorSnackbarService } from '../editor-snackbar.service';
 import { RemoteLabExecService } from '../remote-code-execution/remote-lab-exec.service';
@@ -42,7 +44,8 @@ import { AUTH_SERVICE_STUB } from '../../../test-helper/stubs/auth.service.stubs
     LabExecutionService,
     { provide: AuthService, useValue: AUTH_SERVICE_STUB },
     { provide: DATABASE, useValue: DATABASE_STUB },
-    DbRefBuilder
+    DbRefBuilder,
+    MonacoEditorService
   ]
 })
 export class EditorTestingModule {}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4005,9 +4005,9 @@ ngx-clipboard@^9.0.0:
   dependencies:
     ngx-window-token "0.0.4"
 
-ngx-monaco@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/ngx-monaco/-/ngx-monaco-0.5.2.tgz#bdb6428f37983e59c23c3d781610649487352437"
+ngx-monaco@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/ngx-monaco/-/ngx-monaco-0.6.0.tgz#eebc87ea3bc67398c1cf900cc0b5fa1daebcd044"
 
 ngx-window-token@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
…tializing lab

This commit fixes a regression introduced in https://github.com/machinelabs/machinelabs/commit/e7c646d7f7b984e83c60024d376681f308ca3cfe where newly created labs don't render
the correct file contents because the `MonacoEditor` keeps references to file contents
by name in its own cache.

This means that, every time `MonacoEditor` opens a file (which is when a user selects
a file, or MachineLabs changes the lab model and therefore has a new active file),
it retrieves the contents of that file from its own model cache by the name of that file.

That caused problems when a user created a new lab from within the editor view, because
all MachineLabs does is updating the lab model and binding a new active file to the
editor (most of the time `main.py`), because the file contents of the previous lab where
shown.

This commit ensures that, whenever a new lab is created, that all `MonacoEditor` models
are disposed first. This way we keep the cache for when users stay in a single lab, but
we free it up when the whole lab is a different one.

Fixes #667
  
  