### PR TITLE
fix(EditorView): don't overwrite activeFile reference on file change

### DIFF
--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -411,7 +411,7 @@ export class EditorViewComponent implements OnInit, AfterViewInit {
   }
 
   onFileChange(file: MonacoFile) {
-    this.activeFile = MonacoFileTypeAdapter.monacoFileToLabFile(file);
+    this.activeFile.content = file.content;
   }
 
   private goToLab(lab?: Lab, queryParams?) {


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/machinelabs/machinelabs/commit/e7c646d7f7b984e83c60024d376681f308ca3cfe where we accidently change the
`activeFile` reference with every change that is happening in a file that
is being edited in the editor view.

This caused our app to never propagate changes to the active file back
into the lab that is sent to the server to run it.