### PR TITLE
fix(EditorView): make switching executions work again

### DIFF
--- a/client/src/app/editor/editor.service.ts
+++ b/client/src/app/editor/editor.service.ts
@@ -120,6 +120,7 @@ export class EditorService {
 
   initDirectory(directory: LabDirectory) {
     this.lab.directory = directory;
+    this.monacoEditorService.disposeModels();
     this.fileTreeService.collapseAll(this.lab.directory);
     this.initActiveFile();
   }


### PR DESCRIPTION
In https://github.com/machinelabs/machinelabs/commit/22d42692a4e88699167492f3a43f93c0bf356247,
we forgot to patch `EditorService.initDirectory()` as well which caused our
app to not update the file tree when switching between executions or
unselecting a lab. This commit fixes it.