### PR TITLE
fix: make lab template object immutable

### DIFF
--- a/client/src/app/lab-template.service.ts
+++ b/client/src/app/lab-template.service.ts
@@ -14,6 +14,7 @@ export abstract class LabTemplateService {
 export class InMemoryLabTemplateService extends LabTemplateService {
 
   getTemplate(name: string): Observable<LabTemplate> {
-    return of(LAB_TEMPLATES[name]);
+    const template = LAB_TEMPLATES[name];
+    return of(template ? JSON.parse(JSON.stringify(template)) : null);
   }
 }


### PR DESCRIPTION
This commit fixes a bug in our app that, whenever we change the file contents
of a lab that has been created by a template, we mutated the template instead
of working on a deep copy.

We now ensure that we deep clone lab templates so we don't mutate the original
ones.