### PR TITLE
chore: add editorconfig in root of project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
🎉 😂 

I didn't remove the client `.editorconfig` as it is part of angular-cli. Let me know if it would be okay to drop that one in favour of one global `.editorconfig`.