### PR TITLE
feat(cli): show help and exit on invalid cmds

### DIFF
--- a/cli/src/bootstrap.ts
+++ b/cli/src/bootstrap.ts
@@ -8,6 +8,7 @@ import './commands/logout';
 import './commands/push';
 import './commands/init';
 import './commands/pull';
+import './commands/catch-all'
 
 program
   .version(pgk.version);

--- a/cli/src/commands/catch-all.ts
+++ b/cli/src/commands/catch-all.ts
@@ -1,0 +1,12 @@
+import program = require('commander');
+import * as chalk from 'chalk';
+import { writeFileSync, existsSync } from 'fs';
+import { readLabDirectory, getMlYamlFromPath, ML_YAML, ML_YAML_FILENAME } from '@machinelabs/core';
+
+program
+  .command('*')
+  .action(() => {
+    console.log(chalk.default.yellow(`Invalid command. Here's some help to get you started`));
+    program.outputHelp();
+    process.exit(1);
+  });


### PR DESCRIPTION
I added a `catch-all` command to hint the user with the help and exit the CLI when they run invalid commands.

It's a bit annoying that the catch all is displayed as `*` in the help. Don't think it's a big deal though.

![image](https://user-images.githubusercontent.com/521109/35919385-353433da-0c15-11e8-98ee-f356ceb4c9d5.png)
