### PR TITLE
refactor: remove hardcoded ml.yaml references

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -6,12 +6,12 @@ import { readLabDirectory, getMlYamlFromPath, ML_YAML, ML_YAML_FILENAME } from '
 program
 .command('init')
 .description('Initialize current directory as lab')
-.option('-f --force', 'Overwrite ml.yaml if it already exists')
+.option(`-f --force', 'Overwrite ${ML_YAML_FILENAME} if it already exists`)
 .action(cmd => {
   let configExists = existsSync(ML_YAML_FILENAME);
 
   if (configExists && !cmd.force) {
-    console.error(chalk.default.red('ml.yaml already exists. Run `ml init --force` if you intend to overwrite ml.yaml with default settings'));
+    console.error(chalk.default.red(`${ML_YAML_FILENAME} already exists. Run \`ml init --force\` if you intend to overwrite ${ML_YAML_FILENAME} with default settings`));
     process.exit(1);
   }
 

--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -8,7 +8,7 @@ import { switchMap, map } from 'rxjs/operators';
 
 import { refBuilder } from '../firebase/fb';
 import { Lab, LabDirectory, instanceOfFile } from '@machinelabs/models';
-import { LabApi, readLabDirectory, parseMlYamlFromPath } from '@machinelabs/core';
+import { LabApi, readLabDirectory, parseMlYamlFromPath, ML_YAML_FILENAME } from '@machinelabs/core';
 import { configstore } from '../configstore';
 import { loginFromCache } from '../lib/auth/auth';
 import { environment } from '../environments/environment';
@@ -24,14 +24,14 @@ program
   let parsedMlYaml = parseMlYamlFromPath('.');
 
   if (!parsedMlYaml) {
-    console.error(chalk.default.red('No ml.yaml found. Run `ml init` to create one with default settings'));
+    console.error(chalk.default.red(`No ${ML_YAML_FILENAME} found. Run \`ml init\` to create one with default settings`));
     process.exit(1);;
   }
 
   let cliOptions = parsedMlYaml.cli || {};
   let excludeRegex = cliOptions.exclude && cliOptions.exclude.length ? cliOptions.exclude : [];
   let id = cmd.id || cliOptions.id || shortid.generate();
-  
+
   let readOptions = {
     exclude: excludeRegex,
     excludeBinaries: true,

--- a/client/e2e/editor-view/editor-view.e2e-spec.ts
+++ b/client/e2e/editor-view/editor-view.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { browser, protractor, element, by } from 'protractor';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 
 import { waitForContentReady } from './../utils';
 import { EditorViewPageObject } from './editor-view.page-object';
@@ -23,7 +24,7 @@ describe('Editor-View Component', function() {
     it('should display the current lab file structure', () => {
       expect(editorView.fileTree.count()).toEqual(2);
       expect(editorView.getFileName(0)).toContain('main.py');
-      expect(editorView.getFileName(1)).toContain('ml.yaml');
+      expect(editorView.getFileName(1)).toContain(ML_YAML_FILENAME);
     });
 
     it('should not allow users to edit mandatory file names', () => {

--- a/client/src/app/data/lab-templates.ts
+++ b/client/src/app/data/lab-templates.ts
@@ -1,6 +1,6 @@
 import { SIMPLE_XOR_LAB_CODE } from './xor-lab-code';
 import { SIMPLE_MNIST_CODE } from './mnist-lab-code';
-import { ML_YAML } from '@machinelabs/core';
+import { ML_YAML, ML_YAML_FILENAME } from '@machinelabs/core';
 
 export const LAB_TEMPLATES = {
   'xor': {
@@ -11,7 +11,7 @@ export const LAB_TEMPLATES = {
       name: 'main.py',
       content: SIMPLE_XOR_LAB_CODE
     }, {
-      name: 'ml.yaml',
+      name: ML_YAML_FILENAME,
       content: ML_YAML
     }]
   },
@@ -25,7 +25,7 @@ export const LAB_TEMPLATES = {
       content: SIMPLE_MNIST_CODE
     },
     {
-      name: 'ml.yaml',
+      name: ML_YAML_FILENAME,
       content: ML_YAML
     }]
   }

--- a/client/src/app/editor/completion-providers/lab-config-completion-provider/lab-config-completion-provider.spec.ts
+++ b/client/src/app/editor/completion-providers/lab-config-completion-provider/lab-config-completion-provider.spec.ts
@@ -1,3 +1,4 @@
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 import { LabConfigCompletionProvider } from './lab-config-completion-provider';
 import { DockerImageService } from '../../../docker-image.service';
 import { DOCKER_IMAGE_SERVICE_STUB, WINDOW_SERVICE_STUB } from '../../../../test-helper/stubs';
@@ -67,7 +68,7 @@ describe('LabConfigCompletionProvider', () => {
     });
 
     it('should return all the values', async () => {
-      const model = createModel('ml.yaml', [
+      const model = createModel(ML_YAML_FILENAME, [
         ''
       ]);
 
@@ -77,7 +78,7 @@ describe('LabConfigCompletionProvider', () => {
     });
 
     it('should return all the values when some text is provided', async () => {
-      const model = createModel('ml.yaml', [
+      const model = createModel(ML_YAML_FILENAME, [
         'hard'
       ]);
 
@@ -87,7 +88,7 @@ describe('LabConfigCompletionProvider', () => {
     });
 
     it('should not return already used properties', async () => {
-      const model = createModel('ml.yaml', [
+      const model = createModel(ML_YAML_FILENAME, [
         'hardwareType: cpu',
         ''
       ]);
@@ -98,7 +99,7 @@ describe('LabConfigCompletionProvider', () => {
     });
 
     it('should return the values of the hardwareType', async () => {
-      const model = createModel('ml.yaml', [
+      const model = createModel(ML_YAML_FILENAME, [
         'hardwareType: '
       ]);
 
@@ -121,7 +122,7 @@ describe('LabConfigCompletionProvider', () => {
     });
 
     it('should return the values of the dockerImageId', async () => {
-      const model = createModel('ml.yaml', [
+      const model = createModel(ML_YAML_FILENAME, [
         'dockerImageId: '
       ]);
 

--- a/client/src/app/editor/file-tree/file-tree.component.spec.ts
+++ b/client/src/app/editor/file-tree/file-tree.component.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, } from '@angular/core';
 import { MatDialogModule } from '@angular/material';
 import { File } from '@machinelabs/models';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 import { LAB_STUB, EDITOR_SERVICE_STUB } from '../../../test-helper/stubs';
 import { FileTreeComponent } from './file-tree.component';
 import { EditorService } from '../editor.service';
@@ -127,7 +128,7 @@ describe('FileTreeComponent', () => {
     let items = fixture.debugElement.queryAll(By.css('li'));
     expect(items.length).toEqual(2);
     expect(items[0].nativeElement.textContent).toContain('main.py');
-    expect(items[1].nativeElement.textContent).toContain('ml.yaml');
+    expect(items[1].nativeElement.textContent).toContain(ML_YAML_FILENAME);
   });
 
   it('should render a nested list of files', () => {

--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.html
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.html
@@ -24,7 +24,7 @@
             <ml-file-tree
               (selectFile)="editorService.openFile($event.target, $event.path)"
               [directory]="{ name: '', contents: editorService.lab.directory }"
-              [mandatoryFiles]="['main.py', 'ml.yaml']"
+              [mandatoryFiles]="mandatoryFiles"
               [showActionButtons]="false"></ml-file-tree>
           </mat-drawer>
           <monaco-editor [file]="MonacoFileTypeAdapter.labFileToMonacoFile(activeFile)"></monaco-editor>

--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog, MatDialogRef } from '@angular/material';
 import { File } from '@machinelabs/models';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 
 import { Observable } from 'rxjs/Observable';
 import { take, map } from 'rxjs/operators';
@@ -39,6 +40,8 @@ export class EmbeddedEditorViewComponent implements OnInit {
   noExecutionDialogRef: MatDialogRef<NoExecutionDialogComponent>;
 
   MonacoFileTypeAdapter = MonacoFileTypeAdapter;
+
+  mandatoryFiles = ['main.py', ML_YAML_FILENAME];
 
   constructor(
     private route: ActivatedRoute,

--- a/client/src/app/lab-editor/editor-view/editor-view.component.html
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.html
@@ -42,7 +42,7 @@
                 (addFile)="editorService.openFile($event.target, $event.path)"
                 (selectFile)="editorService.openFile($event.target, $event.path)"
                 [directory]="{ name: '', contents: editorService.lab.directory }"
-                [mandatoryFiles]="['main.py', 'ml.yaml']">
+                [mandatoryFiles]="mandatoryFiles">
               </ml-file-tree>
             </mat-drawer>
             <monaco-editor

--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -9,6 +9,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { filter, tap, map, skip, switchMap, take, share } from 'rxjs/operators';
 
 import { File, ExecutionRejectionReason } from '@machinelabs/models';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 import { XtermComponent } from '../../editor/xterm/xterm.component';
 import {
   EditLabDialogComponent,
@@ -103,6 +104,8 @@ export class EditorViewComponent implements OnInit, AfterViewInit {
   MonacoFileTypeAdapter = MonacoFileTypeAdapter;
 
   pauseModeControl = new FormControl(false);
+
+  mandatoryFiles = ['main.py', ML_YAML_FILENAME];
 
   constructor (private labStorageService: LabStorageService,
                private route: ActivatedRoute,

--- a/client/src/app/lab-storage.service.spec.ts
+++ b/client/src/app/lab-storage.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Inject } from '@angular/core';
 import { File } from '@machinelabs/models';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 import { of } from 'rxjs/observable/of';
 
 import { LabStorageService } from './lab-storage.service';
@@ -64,7 +65,7 @@ describe('LabStorageService', () => {
         expect(lab).toBeDefined();
         expect(lab.directory.length).toBe(2);
         expect(lab.directory[0].name).toEqual('main.py');
-        expect(lab.directory[1].name).toEqual('ml.yaml');
+        expect(lab.directory[1].name).toEqual(ML_YAML_FILENAME);
         expect((<File>lab.directory[0]).content).toEqual('');
       });
     });

--- a/client/src/app/snackbar.service.ts
+++ b/client/src/app/snackbar.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 
 import { Observable } from 'rxjs/Observable';
 import { timer } from 'rxjs/observable/timer';
@@ -14,7 +15,7 @@ export class SnackbarService {
     return this.snackBar.open(text, config.actionLabel, { duration: config.duration });
   }
 
-  notifyInvalidConfig(msg = 'Please check your ml.yaml') {
+  notifyInvalidConfig(msg = `Please check your ${ML_YAML_FILENAME}`) {
     this.notify(`Execution Rejected. ${msg}`);
   }
 

--- a/client/src/test-helper/stubs/lab.stubs.ts
+++ b/client/src/test-helper/stubs/lab.stubs.ts
@@ -1,3 +1,4 @@
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 import { Lab } from '../../app/models/lab';
 
 export const LAB_STUB: Lab = {
@@ -12,7 +13,7 @@ export const LAB_STUB: Lab = {
       content: ''
     },
     {
-      name: 'ml.yaml',
+      name: ML_YAML_FILENAME,
       content: ''
     }
   ],

--- a/server/src/lab-config/lab-config.service.spec.ts
+++ b/server/src/lab-config/lab-config.service.spec.ts
@@ -2,6 +2,7 @@ import 'jest';
 
 import { LabConfigService } from './lab-config.service';
 import { Lab } from '@machinelabs/models';
+import { ML_YAML_FILENAME } from '@machinelabs/core';
 import { PublicLabConfiguration } from '../models/lab-configuration';
 
 let dockerImageId = 'keras_v2-4-x_python_2';
@@ -26,7 +27,7 @@ let lab: Lab = {
   hidden: false,
   directory: [
     {
-      name: 'ml.yaml',
+      name: ML_YAML_FILENAME,
       content: validConfig
     }
   ],

--- a/shared/core/src/lab-config/read-fs.ts
+++ b/shared/core/src/lab-config/read-fs.ts
@@ -1,13 +1,12 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
-
-const ML_YAML_NAME = 'ml.yaml';
+import { ML_YAML_FILENAME } from './ml.yaml';
 
 export const getMlYamlFromPath = (path: string) => {
 
-  let content = readFileSync(join(path, ML_YAML_NAME)).toString();
+  let content = readFileSync(join(path, ML_YAML_FILENAME)).toString();
   return {
     content: content,
-    name: ML_YAML_NAME
+    name: ML_YAML_FILENAME
   };
 };


### PR DESCRIPTION
This PR fixes #683 by removing all the hardcoded `ml.yaml` strings with the constant exposed in `@machinelabs/core`. There is only one place where I couldn't do that, and that is the `functions` directory. 

@cburgdorf If I'm not mistaken, it was not (yet) possible to use the shared packages in the functions, right? Can you elaborate on why this is the case so I can try to improve this :)?