### PR TITLE
fix(FilePreview): Fix image dissapearing in file preview

### DIFF
--- a/client/src/app/editor/file-preview/file-preview-dialog/file-preview-dialog.component.ts
+++ b/client/src/app/editor/file-preview/file-preview-dialog/file-preview-dialog.component.ts
@@ -16,7 +16,8 @@ const ANIMATION_TIMINGS = '400ms cubic-bezier(0.25, 0.8, 0.25, 1)';
     trigger('fade', [
       state('fadeOut', style({ opacity: 0 })),
       state('fadeIn', style({ opacity: 1 })),
-      transition('* => *', animate(ANIMATION_TIMINGS))
+      transition('fadeOut => fadeIn', animate(ANIMATION_TIMINGS)),
+      transition('fadeIn => fadeOut', animate(ANIMATION_TIMINGS))
     ]),
     trigger('slideContent', [
       state('void', style({ transform: 'translate3d(0, 25%, 0) scale(0.9)', opacity: 0 })),


### PR DESCRIPTION
This PR fixes #676.

I'm not a master in animations, but whenever I removed the `* => *` transition, it worked. So I defined the transitions between both states explicitely and now it seems to work fine.

It's weird though and I'm not sure as to why this behaviour occurs. The state is definitely `fadeIn` but the image vanishes after the amount of time specified in the `cubic-bezier` function (400ms).

Maybe it has something to do that `*` also matches `void` or something. But still, not sure how an `animation` could hide an element.