### PR TITLE
chore(models): Add LabConfig model

### DIFF
--- a/shared/core/src/lab-config/parse-fs.ts
+++ b/shared/core/src/lab-config/parse-fs.ts
@@ -1,4 +1,5 @@
 import { getMlYamlFromPath } from './read-fs';
 import { parseMlYaml } from './parse';
+import { LabConfig } from '@machinelabs/models';
 
 export const parseMlYamlFromPath = (path: string) => parseMlYaml(getMlYamlFromPath(path));

--- a/shared/core/src/lab-config/parse.ts
+++ b/shared/core/src/lab-config/parse.ts
@@ -1,7 +1,7 @@
 import { safeLoad } from 'js-yaml';
-import { File } from '@machinelabs/models';
+import { File, LabConfig } from '@machinelabs/models';
 
-export const parseMlYaml = (configFile: File) => {
+export const parseMlYaml = (configFile: File): LabConfig | null => {
   try {
     return safeLoad(configFile.content);
   } catch (error) {

--- a/shared/models/src/index.ts
+++ b/shared/models/src/index.ts
@@ -8,3 +8,4 @@ export * from './mountoption';
 export * from './invocation';
 export * from './special-user';
 export * from './plans';
+export * from './lab-config';

--- a/shared/models/src/lab-config.ts
+++ b/shared/models/src/lab-config.ts
@@ -1,0 +1,20 @@
+export interface LabConfigParameter {
+  'pass-ass': string;
+}
+
+export interface LabConfigInput {
+  name: string;
+  url: string;
+}
+
+export interface LabConfigCli {
+  id?: string;
+  exclude?: string[];
+}
+
+export interface LabConfig {
+  dockerImageId?: string;
+  parameters?: LabConfigParameter[];
+  inputs?: LabConfigInput[];
+  cli?: LabConfigCli;
+}


### PR DESCRIPTION
While I was doing #742, I noticed that we don't have a model for the lab config. So I added one to have some better type inference down the road :).