### PR TITLE
fix(core): Prevent ignoring source directory

### DIFF
--- a/shared/core/package.json
+++ b/shared/core/package.json
@@ -39,7 +39,6 @@
     "@types/shortid": "^0.0.29",
     "isbinaryfile": "^3.0.2",
     "js-yaml": "^3.10.0",
-    "lodash.isarray": "^4.0.0",
     "matcher": "^1.0.0",
     "moment": "^2.18.1",
     "shortid": "^2.2.8"

--- a/shared/core/src/io/lab-fs/read.ts
+++ b/shared/core/src/io/lab-fs/read.ts
@@ -2,7 +2,6 @@ import { readdirSync, statSync, readFileSync } from 'fs';
 import { basename, extname, join } from 'path';
 
 import { File, Directory, LabDirectory, instanceOfDirectory } from '@machinelabs/models';
-import isArray = require('lodash.isarray');
 
 const matcher = require('matcher');
 const isBinaryFile = require('isbinaryfile').sync;
@@ -40,7 +39,11 @@ export const readDirectory = (path: string, options?: ReadOptions): Directory|Fi
   }
 
   // Skip if it matches the exclude regex
-  if (options && isArray(options.exclude) && options.exclude.length && matcher([path], options.exclude).length) {
+  if (path !== '.' &&
+      options &&
+      Array.isArray(options.exclude) &&
+      options.exclude.length &&
+      matcher([path], options.exclude).length) {
     return null;
   }
 

--- a/shared/core/yarn.lock
+++ b/shared/core/yarn.lock
@@ -86,12 +86,6 @@
   version "0.0.0"
   uid ""
 
-"@reactivex/rxjs@^5.4.2":
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/@reactivex/rxjs/-/rxjs-5.4.2.tgz#ab530dbbdab71071369828ef11c8d7ae558d5116"
-  dependencies:
-    symbol-observable "^1.0.1"
-
 "@types/events@*":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
@@ -1743,10 +1737,6 @@ locate-path@^2.0.0:
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
-
-lodash.isarray@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
 
 lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.4"


### PR DESCRIPTION
fixes #746

So, what was wrong? When reading the lab directory, we use the `.` as source path, because it's the current working directory. But, because we wrote `- .*` as ignore pattern (which isn't a glob pattern because we use [`matcher`](http://github.com/sindresorhus/matcher) which is just simple wildcard matching), it actually matches the source directory, begin just a dot. This means it exited early and no files where found.

I want to take a look if we should fix it differently. I think it would be better to start reading the lab from `process.cwd()` instead of `.` to make it more clear that it uses the current working directory. This should fix the issue as well and might be cleaner.

Feedback welcome.