### PR TITLE
fix(cli): ignore all dot directories by default

### DIFF
--- a/shared/core/src/lab-config/ml.yaml.ts
+++ b/shared/core/src/lab-config/ml.yaml.ts
@@ -38,9 +38,8 @@ dockerImageId: keras_v2-0-x_python_3-1
 # Everything on the "cli" node configures how the CLI interacts with the MachineLabs platform
 cli:
   exclude:
-    - '.vscode'
+    - '.*'
     - '__pycache__'
-    - '.git'
 `;
 
 export const ML_YAML_FILENAME = 'ml.yaml';


### PR DESCRIPTION
After @SamVerschueren fixed #746 this patch changes the default excludes for the `ml.yaml` to ignore all dot directories.