### PR TITLE
fix(server): support special characters in output filename

### DIFF
--- a/server/src/code-runner/uploader/docker-file-uploader.ts
+++ b/server/src/code-runner/uploader/docker-file-uploader.ts
@@ -70,7 +70,7 @@ export class DockerFileUploader {
       containerId,
       '/bin/bash',
       '-c',
-      'cd /run/outputs && find . -maxdepth 1 -type f | xargs stat --printf "%n:::%s"'
+      'cd /run/outputs && find . -maxdepth 1 -type f | xargs -d "\n" stat --printf "%n:::%s"'
     ]).pipe(
       filter(val => val.origin === OutputType.Stdout),
       map(val =>
@@ -118,7 +118,7 @@ Backers on ${bold(PATREON_URL)} can upload ${BACKER_PLAN.maxFileUploads} files p
     return getCurlForUpload(
       environment.firebaseConfig.storageBucket,
       file,
-      `executions/${invocation.id}/outputs/${file}`,
+      `executions/${invocation.id}/outputs/${encodeURIComponent(file)}`,
       token,
       headers
     );

--- a/server/src/util/file-upload.ts
+++ b/server/src/util/file-upload.ts
@@ -5,8 +5,8 @@ export const getCurlForUpload = (
   authToken: string,
   headers: Map<string, string> = new Map()
 ) => {
-  const headerStr = Array.from(headers).reduce((prev, current) => prev + ` -H ${current[0]}:${current[1]}`, '');
+  const headerStr = Array.from(headers).reduce((prev, current) => prev + ` -H "${current[0]}:${current[1]}"`, '');
 
   // tslint:disable-next-line
-  return `curl --silent --show-error ${headerStr} --upload-file ${file} -H "Authorization: Bearer ${authToken}" https://storage.googleapis.com/${bucketName}/${storeFullPath}`;
+  return `curl --silent --show-error ${headerStr} --upload-file "${file}" -H "Authorization: Bearer ${authToken}" "https://storage.googleapis.com/${bucketName}/${storeFullPath}"`;
 };


### PR DESCRIPTION
fixes #685 

I wrapped all the values in double quotes to make sure that spaces or other special characters like parenthesis can't screw up the curl command, which it did.

In order to test this, you can run the following code

```python
import os;
os.system("echo foo > './outputs/foo(1).txt'")
os.system("echo foo > ./outputs/foo2.txt")
os.system("ls ./outputs")
```

Make sure to wrap the filename in single quotes when you use parenthesis.

After I fixed this, I noticed that files with a space for instance also failed. The first reason was that the `xargs stat` command splits on whitespace. I changed it so it splits on newlines (hope this doesn't break other stuff but thought it was safe). The last step in this is that we also need to encode the filename in the upload url, otherwise the URL is invalid.