### PR TITLE
fix(firebase/functions): fix deploy script

### DIFF
--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -6,7 +6,7 @@
     "cp__node_modules": "cp -R ./node_modules ./dist/node_modules",
     "cp__package": "cp -R ./package.json ./dist/package.json",
     "copy": "npm run cp__node_modules && npm run cp__package",
-    "node_modules": "rm -rf ./node_modules && yarn install",
+    "node_modules": "rm -rf ./node_modules && npx yarn install",
     "build:pre": "npm run node_modules && npm run clean_dist && npm run mk_dist && npm run copy",
     "build": "npm run build:pre && tsc",
     "deploy": "npm run build && firebase deploy && npm run clean_dist",


### PR DESCRIPTION
We introduced a regression in https://github.com/machinelabs/machinelabs/commit/f7d15eba3733fbe0424b32e894cc3f787b5fdc39 that,
when `yarn` isn't globally installed anymore the firebase functions' deploy
script will throw an error. This is not a problem when `yarn` is globally
available, which should be the case for most of us as of now.

However, since we switched to `npx` it's probably better to streamline
the deploy script as well and never assume a global `yarn` is available.