### PR TITLE
fix: use npx in npm scripts for yarn commands

### DIFF
--- a/admin-cli/package.json
+++ b/admin-cli/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "echo \"Compiling admin-cli\" && (cd ../shared && node build.js --install) && tsc",
-    "mla:build": "yarn run build && yarn run mla",
+    "mla:build": "npm run build && npm run mla",
     "mla": "node ./dist/index.js",
     "lint:check": "tslint -c ./tslint.json \"{commands,config-templates,lib}/**/*.ts\"",
     "lint:fix": "tslint --fix -c ./tslint.json \"{commands,config-templates,lib}/**/*.ts\"",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -6,7 +6,7 @@
     "cp__node_modules": "cp -R ./node_modules ./dist/node_modules",
     "cp__package": "cp -R ./package.json ./dist/package.json",
     "copy": "npm run cp__node_modules && npm run cp__package",
-    "node_modules": "rm -rf ./node_modules && yarn install",
+    "node_modules": "rm -rf ./node_modules && npx yarn install",
     "build:pre": "npm run node_modules && npm run clean_dist && npm run mk_dist && npm run copy",
     "build": "npm run build:pre && tsc",
     "deploy": "npm run build && firebase deploy && npm run clean_dist",

--- a/rest-api/package.json
+++ b/rest-api/package.json
@@ -23,7 +23,7 @@
     "moduleFileExtensions": ["ts", "tsx", "js", "json"]
   },
   "scripts": {
-    "node_modules": "rm -rf ./node_modules && yarn install",
+    "node_modules": "rm -rf ./node_modules && npx yarn install",
     "build": "node ./build/build.js",
     "start": "node ./dist/index.js",
     "lint:check": "tslint -c tslint.json 'src/**/*.ts'",


### PR DESCRIPTION
It turns out that npm doesn't actually use the local `yarn` installation
of a package within npm scripts, which causes some of our npm scripts to
fail.

This commit ensures the local version of yarn is used by running every
yarn command through `npx` withim npm scripts as well.