### PR TITLE
fix(client): Prevent editor view from showing horizontal scroll bars

### DIFF
--- a/client/cypress/integration/editor-view_spec.ts
+++ b/client/cypress/integration/editor-view_spec.ts
@@ -56,6 +56,13 @@ describe('Editor View', () => {
       editorView.getFileTree().should('be.visible');
     });
 
+    it('should not display a horizontal scrollbar when file structure is visible', () => {
+      editorView.toggleFileTree();
+      editorView.getEditorLayoutPanel().should(el => {
+        expect(el[0].clientWidth).to.eq(el[0].scrollWidth);
+      });
+    });
+
     describe('File Tree', () => {
 
       it('should display current lab file structure', () => {

--- a/client/cypress/support/po.ts
+++ b/client/cypress/support/po.ts
@@ -40,6 +40,10 @@ export class EditorViewPageObject {
     return cy.get('monaco-editor');
   }
 
+  getEditorLayoutPanel() {
+    return cy.get('ml-editor-layout-panels');
+  }
+
   getConsolePanel() {
     return cy.get('ml-xterm');
   }

--- a/client/src/app/editor/layout/editor-layout-panel.component.ts
+++ b/client/src/app/editor/layout/editor-layout-panel.component.ts
@@ -9,8 +9,8 @@ import { Component } from '@angular/core';
     `
     :host {
       display: flex;
-      flex: 1;
       position: relative;
+      width: 100%;
     }
   `
   ]

--- a/client/src/app/editor/layout/editor-layout-panels.component.ts
+++ b/client/src/app/editor/layout/editor-layout-panels.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
     `
     :host {
       display: flex;
-      flex: 1;
+      width: 100%;
     }
   `
   ]

--- a/client/src/app/lab-editor/editor-view/editor-view.component.scss
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.scss
@@ -24,7 +24,7 @@ mat-drawer-container {
 }
 
 monaco-editor {
-  flex: 1;
+  width: 100%;
 }
 
 .ml-editor-restore-message {


### PR DESCRIPTION
fixes #776 

Apparently this was caused somehow by flex. Setting `flex: 1` seems not the same as `width: 100%`. I couldn't find why this was the case. Flexbox still has some mysteries :). 

For Chrome, setting `width: 100%` was enough, but that didn't work for Firefox. I had to remove `flex: 1` entirely.

@PascalPrecht Can you verify this again locally to see if I didn't broke something else? I couldn't find anything but just to be sure :).