### PR TITLE
fix: Use npx to install and build the shared modules

### DIFF
--- a/shared/build.js
+++ b/shared/build.js
@@ -12,12 +12,12 @@ const doInstall = !!process.argv.includes("--install");
 let buildOrder = ["models", "core", "metrics", "supervisor"];
 
 const buildCmd = dir =>
-  execute(`(cd ${dir} && ./node_modules/typescript/bin/tsc)`, {
+  execute(`(cd ${dir} && npx tsc)`, {
     stdio: "inherit"
   });
 
 const installAndBuildCmd = dir =>
-  execute(`(cd ${dir} && yarn install && ./node_modules/typescript/bin/tsc)`, {
+  execute(`(cd ${dir} && npx yarn install && npx tsc)`, {
     stdio: "inherit"
   });
 


### PR DESCRIPTION
`npx` takes the binary from `node_modules/.bin` which also has `tsc`. But the main fix was that the `yarn install` script didn't use `npx` yet which failed on my machine as I don't have yarn globally installed anymore.