### PR TITLE
fix: Show output of ml run command on separate line in landing page console

### DIFF
--- a/client/src/app/landing-page/landing-page.component.html
+++ b/client/src/app/landing-page/landing-page.component.html
@@ -149,8 +149,8 @@
       <div class="ml-landing-page-console-container">
         <ml-console>
           <span ml-console-cmd>$ npm install -g @machinelabs/cli<br>
-          $ ml run --locally
-          $ Using Tensorflow Backend.</span>
+          $ ml run --locally<br>
+          Using Tensorflow Backend.</span>
         </ml-console>
         <div class="ml-landing-page-console-text">
           <p>The MachineLabs command line interface lets you <span>import existing projects</span>, <span>clone labs</span> from the platform and <span>run them</span> either locally or in our high performance cloud.</p>


### PR DESCRIPTION
I checked the `ml-console` command and it just projects the `ml-console-cmd` content. It doesn't do anything special other than that.

Here's a link to the component itself for review https://github.com/machinelabs/machinelabs/blob/master/client/src/app/shared/console/console.component.html