### PR TITLE
fix(client): ensure embedded editor view fills available viewport

### DIFF
--- a/client/cypress/integration/editor-view_spec.ts
+++ b/client/cypress/integration/editor-view_spec.ts
@@ -63,6 +63,14 @@ describe('Editor View', () => {
       });
     });
 
+    it('should fill the available viewport height', () => {
+      editorView.getEditorLayoutMain().then(main => {
+        editorView.getEditorLayoutPanel().should(el => {
+          expect(el[0].clientHeight).to.eq(main[0].clientHeight);
+        });
+      });
+    });
+
     describe('File Tree', () => {
 
       it('should display current lab file structure', () => {

--- a/client/cypress/integration/embedded-editor-view_spec.ts
+++ b/client/cypress/integration/embedded-editor-view_spec.ts
@@ -13,4 +13,12 @@ describe('Embedded Editor View', () => {
     cy.visit('/embedded?tab=console');
     editorView.getActiveTab().contains('Console');
   });
+
+  it('should fill the available viewport height', () => {
+    editorView.getEditorLayoutMain().then(main => {
+      editorView.getEditorLayoutPanel().should(el => {
+        expect(el[0].clientHeight).to.eq(main[0].clientHeight);
+      });
+    });
+  });
 });

--- a/client/cypress/support/po.ts
+++ b/client/cypress/support/po.ts
@@ -44,6 +44,10 @@ export class EditorViewPageObject {
     return cy.get('ml-editor-layout-panels');
   }
 
+  getEditorLayoutMain() {
+    return cy.get('ml-editor-layout-main');
+  }
+
   getConsolePanel() {
     return cy.get('ml-xterm');
   }

--- a/client/src/app/editor/layout/editor-layout-panels.component.ts
+++ b/client/src/app/editor/layout/editor-layout-panels.component.ts
@@ -10,6 +10,7 @@ import { Component } from '@angular/core';
     :host {
       display: flex;
       width: 100%;
+      height: 100%;
     }
   `
   ]

--- a/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.scss
+++ b/client/src/app/embedded-editor/embedded-editor-view/embedded-editor-view.component.scss
@@ -29,11 +29,7 @@ mat-drawer-container {
 }
 
 monaco-editor {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  width: 100%;
 }
 
 .ml-editor-panel-cta-bar {


### PR DESCRIPTION
As discussed in #792, we've introduced a bug in https://github.com/machinelabs/machinelabs/commit/f0daa615ea54d7726023d7e75213c54eba67c8a3, that the editor panels won't fill the available viewport anymore in embedded editor
view.

This is because we've removed `flex: 1`, so the main content doesn't
scroll horizontally when the file drawer is opened. In embedded views
however, this is not a problem because we always have a file tree that
overlays, rather than pushing the rest of the content aside.

This commit brings back `flex: 1` in the main editor layout inside the
embedded editor view.

Fixes #792