### PR TITLE
fix(firebase/rules): only allow system users to write into common lab executions

### DIFF
--- a/firebase/rules/database.rules.bolt
+++ b/firebase/rules/database.rules.bolt
@@ -62,6 +62,10 @@ type String500 extends String {
   validate() { this.length <= 500 }
 }
 
+type ServerWritable {
+  validate() { isSystem() }
+}
+
 type ServerWritableString extends String100 {
   validate() { isSystem() }
 }
@@ -128,10 +132,15 @@ type Execution {
   server_info: ServerWritableString,
   hardware_type: ServerWritableString,
   user_id: ServerWritableString,
-  lab: InvocationLab,
+  lab: ExecutionLab,
   status: ServerWritableString,
   hidden: Boolean | Null,
   name: String100 | Null
+}
+
+type ExecutionLab extends InvocationLab {
+  id: ServerWritable,
+  directory: ServerWritable
 }
 
 type ExecutionMessage {

--- a/firebase/rules/database.rules.json
+++ b/firebase/rules/database.rules.json
@@ -195,12 +195,12 @@
             ".validate": "newData.isString() && newData.val().length <= 100 && auth.uid == 'SYSTEM_USER'"
           },
           "lab": {
-            ".validate": "newData.hasChildren(['id', 'directory'])",
+            ".validate": "newData.hasChildren(['id', 'directory', 'id', 'directory'])",
             "id": {
-              ".validate": "newData.isString() && newData.val().length <= 100"
+              ".validate": "newData.isString() && newData.val().length <= 100 && auth.uid == 'SYSTEM_USER'"
             },
             "directory": {
-              ".validate": "newData.isString()"
+              ".validate": "newData.isString() && auth.uid == 'SYSTEM_USER'"
             },
             "$other": {
               ".validate": "false"


### PR DESCRIPTION
Fixes the issue that authed users were able to write into their own `common/lab` executions, this should only be allowed for system users.

Fixes: #791 