### PR TITLE
chore: make prettier ignore package.json files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 bin
 database.rules.json
+package.json


### PR DESCRIPTION
This is due to yarn reformatting the file on every `install` while,
prettier is formatting it all over again.