### PR TITLE
test(firebase/rules): fixes broken test that validates tags length

### DIFF
--- a/firebase/rules/tests/labs.spec.ts
+++ b/firebase/rules/tests/labs.spec.ts
@@ -163,12 +163,10 @@ describe('/labs', () => {
     it('Lab tags cannot be longer than 50 characters', () => {
       const labWithLongTags = {
         ...testLab,
-        tags: [string51],
-        created_at: undefined,
-        modified_at: undefined
+        tags: [string51]
       };
 
-      expect(currentUser).cannotWrite('/labs/1/common/', labWithLongTags);
+      expect(currentUser).cannotWrite('/labs/1/common', labWithLongTags);
     });
   });
 });


### PR DESCRIPTION
As raised in #800, it turns out that one of our tests for the lab database rules
is invalid. Labs should invalidate if any of the tags attached to the lab exceed
a certain limit (50 characters). The test should verify that this invalidation
takes place and prior to this commit, it did in fact pass. However, as @maartentibau
pointed out, the actual reason it passed (lab isn't writable) was because the
test data was incorrect.

Fixing the data structure revealed that the test didn't pass anymore.

In reality, our rules work perfectly fine, it's just that in our testing
environment we're running the test against a wrong path:

Should be

```
/labs/1/common
```

Instead of

```
/labs/1/common/
```

Targaryen simply maps the rules to the given paths, and as there are no validation
rules for the path /labs/1/common/ (but for /labs/1/common), write operations to
that path would always pass.

Fixes #800