### PR TITLE
uiux(client): change notification when execution is unselected

### DIFF
--- a/client/src/app/lab-editor/editor-view/editor-view.component.ts
+++ b/client/src/app/lab-editor/editor-view/editor-view.component.ts
@@ -434,7 +434,7 @@ export class EditorViewComponent implements OnInit {
 
     setTimeout(() => {
       this.executionMetadataSidebar.close();
-      this.snackbarService.notifyLabRestored();
+      this.snackbarService.notifyExecutionUnselected();
     }, METADATA_SIDEBAR_OPEN_TIMEOUT);
   }
 

--- a/client/src/app/snackbar.service.ts
+++ b/client/src/app/snackbar.service.ts
@@ -61,6 +61,10 @@ export class SnackbarService {
     return this.notify('Execution finished', { actionLabel: 'Show output', duration: 0 });
   }
 
+  notifyExecutionUnselected() {
+    return this.notify('Execution unselected');
+  }
+
   notifyExecutionFinished() {
     this.notify('Execution finished');
   }


### PR DESCRIPTION
Saying "Lab restored." doesn't make a lot of sense for users that
aren't familiar with the underlying algorithm.