### PR TITLE
Improve login pop-up experience

### DIFF
--- a/client/src/app/auth/auth.service.ts
+++ b/client/src/app/auth/auth.service.ts
@@ -6,6 +6,6 @@ export abstract class AuthService {
   abstract requireAuth(): Observable<LoginUser>;
   abstract requireAuthOnce(): Observable<LoginUser>;
   abstract signOut(): Observable<any>;
-  abstract signInWithGitHub(): Observable<LoginUser>;
+  abstract signInWithCredential(credential: firebase.auth.AuthCredential): Observable<LoginUser>;
   abstract linkOrSignInWithGitHub(): Observable<LoginUser>;
 }

--- a/client/src/app/auth/offline-auth.service.ts
+++ b/client/src/app/auth/offline-auth.service.ts
@@ -35,13 +35,13 @@ export class OfflineAuthService implements OfflineAuth {
     return this.requireAuth().pipe(take(1));
   }
 
-  signInWithGitHub(): Observable<LoginUser> {
+  signInWithCredential(credential: firebase.auth.AuthCredential): Observable<LoginUser> {
     this.user.isAnonymous = false;
     return of(this.user);
   }
 
   linkOrSignInWithGitHub(): Observable<LoginUser> {
-    return this.signInWithGitHub();
+    return this.signInWithCredential({ providerId: '', signInMethod: '' });
   }
 
   signOut(): Observable<any> {

--- a/client/src/app/toolbar/toolbar-menu/toolbar-menu.component.spec.ts
+++ b/client/src/app/toolbar/toolbar-menu/toolbar-menu.component.spec.ts
@@ -67,6 +67,7 @@ describe('ToolbarMenuComponent', () => {
     const loginButton = fixture.debugElement.query(By.css('.mat-menu-panel button'));
 
     loginButton.triggerEventHandler('click', null);
+
     expect(authService.linkOrSignInWithGitHub).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
This PR updates the login flow to first check if a user exists, if it does, attempts the link process which then reverts to the signup process. If they do not we simply try to login for the first time. This addresses issue #805.

I have added several tests and run them all locally to ensure they pass. This is ready for review.