### PR TITLE
fix(server): allow server to compile even if slack logging is missing from the environment configuration file

### DIFF
--- a/server/src/environments/environment.production-rijnbuurt.ts
+++ b/server/src/environments/environment.production-rijnbuurt.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import Environment from 'models/environment';
+
+export const environment: Environment = {
   firebaseConfig: {
     apiKey: 'AIzaSyDB6mmk8CDyy9D6DpYQgzLd3-wwY5WDSEc',
     authDomain: 'machinelabs-production.firebaseapp.com',

--- a/server/src/environments/environment.production.ts
+++ b/server/src/environments/environment.production.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import Environment from 'models/environment';
+
+export const environment: Environment = {
   firebaseConfig: {
     apiKey: 'AIzaSyDB6mmk8CDyy9D6DpYQgzLd3-wwY5WDSEc',
     authDomain: 'machinelabs-production.firebaseapp.com',

--- a/server/src/environments/environment.production2.ts
+++ b/server/src/environments/environment.production2.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import Environment from 'models/environment';
+
+export const environment: Environment = {
   firebaseConfig: {
     apiKey: 'AIzaSyDB6mmk8CDyy9D6DpYQgzLd3-wwY5WDSEc',
     authDomain: 'machinelabs-production.firebaseapp.com',

--- a/server/src/environments/environment.staging-portimao.ts
+++ b/server/src/environments/environment.staging-portimao.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import Environment from 'models/environment';
+
+export const environment: Environment = {
   firebaseConfig: {
     apiKey: 'AIzaSyDu0Qds2fWo8iZMcCj0T_ANqD9V4E0_9QY',
     authDomain: 'machinelabs-a73cd.firebaseapp.com',

--- a/server/src/environments/environment.staging.ts
+++ b/server/src/environments/environment.staging.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import Environment from 'models/environment';
+
+export const environment: Environment = {
   firebaseConfig: {
     apiKey: 'AIzaSyDu0Qds2fWo8iZMcCj0T_ANqD9V4E0_9QY',
     authDomain: 'machinelabs-a73cd.firebaseapp.com',

--- a/server/src/environments/environment.staging2.ts
+++ b/server/src/environments/environment.staging2.ts
@@ -1,4 +1,6 @@
-export const environment = {
+import Environment from 'models/environment';
+
+export const environment: Environment = {
   firebaseConfig: {
     apiKey: 'AIzaSyDu0Qds2fWo8iZMcCj0T_ANqD9V4E0_9QY',
     authDomain: 'machinelabs-a73cd.firebaseapp.com',

--- a/server/src/logging/index.ts
+++ b/server/src/logging/index.ts
@@ -25,14 +25,14 @@ if (!slackToken) {
   config.appenders['slack-all'] = {
     type: 'slack',
     token: slackToken,
-    channel_id: environment.slackLogging.allChannel,
+    channel_id: environment.slackLogging ? environment.slackLogging.allChannel : '',
     username: 'ml-bot'
   };
 
   config.appenders['slack-errors'] = {
     type: 'slack',
     token: slackToken,
-    channel_id: environment.slackLogging.errorChannel,
+    channel_id: environment.slackLogging ? environment.slackLogging.errorChannel : '',
     username: 'ml-bot'
   };
 

--- a/server/src/models/environment.ts
+++ b/server/src/models/environment.ts
@@ -1,0 +1,17 @@
+export default interface Environment {
+  firebaseConfig: {
+    apiKey: string;
+    authDomain: string;
+    databaseURL: string;
+    projectId?: string;
+    storageBucket: string;
+    messagingSenderId: string;
+  };
+  serverId: string;
+  pullImages?: boolean;
+  rootMountPath: string;
+  slackLogging?: {
+    allChannel: string;
+    errorChannel: string;
+  };
+};

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -18,7 +18,8 @@
     "stripInternal": true,
     "paths": {
       "firebase": ["./node_modules/firebase"],
-      "rxjs/*": ["./node_modules/rxjs/*"]
+      "rxjs/*": ["./node_modules/rxjs/*"],
+      "models/*": ["./src/models/*"]
     },
     "baseUrl": "",
     "typeRoots": ["./node_modules/@types"],


### PR DESCRIPTION
This PR addresses the situation where omitting the `slackLogging` property from the server configuration file, the server would fail to compile due to accessing a property of a potentially undefined object. For this, the following fixes were applied:
- Introduce the `Environment` interface where we specify the shape of a configuration object and properly mark properties that are optional. This is will solve any complains `tsc` might have with trying to access a (potentially) absent optional property plus will improve editor type hinting. Also by making the environment config objects of this type will ensure correct shape of the files.
- Guard against accessing a property of a potential null object (the `slackLogging` property of the environment config)

Fixes: #443