### PR TITLE
uiux(client): open guides & examples in new tab

### DIFF
--- a/client/src/app/lab-editor/editor-footer/editor-footer.component.html
+++ b/client/src/app/lab-editor/editor-footer/editor-footer.component.html
@@ -3,7 +3,7 @@
     <div class="ml-editor-footer-cta-bar">
       <button *ngIf="executionId" mat-button mat-raised-button color="primary" class="elevated" (click)="openEmbedDialog()">Embed</button>
       <a href="mailto:hello@machinelabs.ai?subject=Hey, I've got some feedback!" title="Leave feedback to improve MachineLabs"  mat-raised-button color="primary" class="elevated">Feedback</a>
-     <a href="https://docs.machinelabs.ai" title="MachineLabs Documentation" mat-button class="elevated">Guides & Examples</a>
+     <a href="https://docs.machinelabs.ai" title="MachineLabs Documentation" mat-button class="elevated" target="_blank">Guides & Examples</a>
     </div>
     <div class="ml-editor-footer-content">
       <ml-execution-status [execution]="execution"></ml-execution-status>


### PR DESCRIPTION
Updates the "Guides & Examples" link to open in a new tab so that the user doesn't have to go back and forth in the browser.