### PR TITLE
chore(CI): enforce yarn version 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 sudo: required
 language: node_js
+before_install:
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn=1.6.0
 dist: trusty
-cache: yarn
+cache:
+  yarn: true
 notifications:
   email: false
 addons:


### PR DESCRIPTION
This is considered best practice to ensure builds are working across the
board. In fact, right now we have the problem that there's a bug in 1.7.0
which prevents our builds to pass. Until 1.8.0 is released, we have to nail
the version to 1.6.0 as CI uses the latest available version by default.