### PR TITLE
feat (client): add social media and content description meta tags

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit, HostBinding } from '@angular/core';
 import { Router, NavigationStart, NavigationEnd, NavigationError, NavigationCancel } from '@angular/router';
 import { ProgressBarService } from './shared/progress-bar/progress-bar.service';
 
+import { MetatagService } from './metatag.service';
+
 declare const require: any;
 const { version } = require('../../package.json');
 
@@ -30,7 +32,9 @@ const { version } = require('../../package.json');
 export class AppComponent implements OnInit {
   @HostBinding('attr.ml-version') version = version;
 
-  constructor(private router: Router, private progressBarService: ProgressBarService) {}
+  constructor(private router: Router, private meta: MetatagService, private progressBarService: ProgressBarService) {
+    this.meta.generateTags({});
+  }
 
   ngOnInit() {
     this.router.events.subscribe(event => {

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { UserService } from './user/user.service';
 import { AuthService, FirebaseAuthService, OfflineAuthService } from './auth';
 import { SnackbarService } from './snackbar.service';
 import { LocationHelper } from './util/location-helper';
+import { MetatagService } from './metatag.service';
 
 import { AppComponent } from './app.component';
 
@@ -76,6 +77,7 @@ const AnimationsModule = [environment.testing ? NoopAnimationsModule : BrowserAn
     UserService,
     DockerImageService,
     SnackbarService,
+    MetatagService,
     DbRefBuilder,
     { provide: DATABASE, useFactory: databaseFactory },
     { provide: AuthService, useClass: environment.offline ? OfflineAuthService : FirebaseAuthService },

--- a/client/src/app/metatag.service.ts
+++ b/client/src/app/metatag.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { Meta } from '@angular/platform-browser';
+
+@Injectable()
+export class MetatagService {
+  // default values
+  config = {
+    title: 'MachineLabs',
+    description:
+      'MachineLabs is a platform that makes machine learning available to everyone through experiments in the browser.',
+    image: 'https://machinelabs.ai/assets/images/ml-app.png'
+  };
+
+  constructor(private meta: Meta) {}
+
+  /**
+   * Can be used to override default meta tags on a component basis
+   * @param config: {title, description, image}
+   */
+  generateTags(config) {
+    this.config = Object.assign({}, this.config, config);
+
+    this.meta.updateTag({ name: 'twitter:card', content: 'summary_large_image' });
+    this.meta.updateTag({ name: 'twitter:site', content: '@machinelabs_ai' });
+    this.meta.updateTag({ name: 'twitter:title', content: this.config.title });
+    this.meta.updateTag({ name: 'twitter:description', content: this.config.description });
+    this.meta.updateTag({ name: 'twitter:image', content: this.config.image });
+
+    this.meta.updateTag({ property: 'og:type', content: 'website' });
+    this.meta.updateTag({ property: 'og:site_name', content: 'MachineLabs' });
+    this.meta.updateTag({ property: 'og:title', content: this.config.title });
+    this.meta.updateTag({ property: 'og:description', content: this.config.description });
+    this.meta.updateTag({ property: 'og:image', content: this.config.image });
+  }
+}

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -3,10 +3,26 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="description" content="">
+  <meta name="description" content="MachineLabs is a platform that makes machine learning available to everyone through experiments in the browser.">
   <title>MachineLabs - Machine Learning for everyone</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Twitter card defaults -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@machinelabs_ai">
+  <meta name="twitter:title" content="MachineLabs">
+  <meta name="twitter:description" content="MachineLabs is a platform that makes machine learning available to everyone through experiments in the browser.">
+  <meta name="twitter:image" content="https://machinelabs.ai/assets/images/ml-app.png">
+
+  <!-- OpenGraph card defaults -->
+  <meta property="og:type" content="website"/>
+  <meta property="og:site_name" content="MachineLabs"/>
+  <meta property="og:title" content="MachineLabs" />
+  <meta property="og:description" content="MachineLabs is a platform that makes machine learning available to everyone through experiments in the browser." />
+  <meta property="og:url" content="https://machinelabs.ai/" />
+
+  <meta property="og:image" content="https://machinelabs.ai/assets/images/ml-app.png" />
 
   <!-- Disable tap highlight on IE -->
   <meta name="msapplication-tap-highlight" content="no">


### PR DESCRIPTION
This adds default meta tags in the index.html as well as creates a service that will allow for dynamic updates to the social media related metatags on a component basis. Currently, the app component updates with the default configurations to show how this would occur. 